### PR TITLE
Temp fix for Steam not launching SMAPI (Mac/Linux)

### DIFF
--- a/src/StardewModdingAPI/unix-launcher.sh
+++ b/src/StardewModdingAPI/unix-launcher.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # MonoKickstart Shell Script
 # Written by Ethan "flibitijibibo" Lee
-# Modified for StardewModdingAPI by Viz and Pathoschild
+# Modified for StardewModdingAPI by Viz, Pathoschild and EnderHDMC
 
 # Move to script's directory
 cd "`dirname "$0"`"
@@ -30,38 +30,54 @@ if [ "$UNAME" == "Darwin" ]; then
 	cp StardewValley.bin.osx StardewModdingAPI.bin.osx
 	open -a Terminal ./StardewModdingAPI.bin.osx $@
 else
-	# choose launcher
-	LAUNCHER=""
-	if [ "$ARCH" == "x86_64" ]; then
-		ln -sf mcs.bin.x86_64 mcs
-		cp StardewValley.bin.x86_64 StardewModdingAPI.bin.x86_64
-		LAUNCHER="./StardewModdingAPI.bin.x86_64 $@"
+	# check if "--disable-smapi" argument was passed (checks all arguments)
+	if [[ $@ =~ "--disable-smapi" ]]; then
+		# launch vanilla Stardew Valley
+		./StardewValley-original $@
 	else
-		ln -sf mcs.bin.x86 mcs
-		cp StardewValley.bin.x86 StardewModdingAPI.bin.x86
-		LAUNCHER="./StardewModdingAPI.bin.x86 $@"
-	fi
+		# launch smapi
 
-	# get cross-distro version of POSIX command
-	COMMAND=""
-	if command -v command 2>/dev/null; then
-		COMMAND="command -v"
-	elif type type 2>/dev/null; then
-		COMMAND="type"
-	fi
+		# choose launcher
+		LAUNCHER=""
+		if [ "$ARCH" == "x86_64" ]; then
+			ln -sf mcs.bin.x86_64 mcs
+			cp StardewValley.bin.x86_64 StardewModdingAPI.bin.x86_64
+			LAUNCHER="./StardewModdingAPI.bin.x86_64 $@"
+		else
+			ln -sf mcs.bin.x86 mcs
+			cp StardewValley.bin.x86 StardewModdingAPI.bin.x86
+			LAUNCHER="./StardewModdingAPI.bin.x86 $@"
+		fi
 
-	# open SMAPI in terminal
-	if $COMMAND x-terminal-emulator 2>/dev/null; then
-		x-terminal-emulator -e "$LAUNCHER"
-	elif $COMMAND gnome-terminal 2>/dev/null; then
-		gnome-terminal -e "$LAUNCHER"
-	elif $COMMAND xterm 2>/dev/null; then
-		xterm -e "$LAUNCHER"
-	elif $COMMAND konsole 2>/dev/null; then
-		konsole -e "$LAUNCHER"
-	elif $COMMAND terminal 2>/dev/null; then
-		terminal -e "$LAUNCHER"
-	else
-		$LAUNCHER
+		# check if "--disable-terminal" or "--disable-console" argument was passed (checks all arguments)
+		if [[ $@ =~ --disable-terminal ]] || [[ $@ =~ --disable-console ]]; then
+			# launch SMAPI without terminal to bypass a bug where steam does not launch the game when using terminal
+			$LAUNCHER
+		else
+			# launch SMAPI normally (with terminal)
+
+			# get cross-distro version of POSIX command
+			COMMAND=""
+			if command -v command 2>/dev/null; then
+				COMMAND="command -v"
+			elif type type 2>/dev/null; then
+				COMMAND="type"
+			fi
+
+			# open SMAPI in terminal
+			if $COMMAND x-terminal-emulator 2>/dev/null; then
+				x-terminal-emulator -e "$LAUNCHER"
+			elif $COMMAND gnome-terminal 2>/dev/null; then
+				gnome-terminal -e "$LAUNCHER"
+			elif $COMMAND xterm 2>/dev/null; then
+				xterm -e "$LAUNCHER"
+			elif $COMMAND konsole 2>/dev/null; then
+				konsole -e "$LAUNCHER"
+			elif $COMMAND terminal 2>/dev/null; then
+				terminal -e "$LAUNCHER"
+			else
+				$LAUNCHER
+			fi
+		fi
 	fi
 fi


### PR DESCRIPTION
Added support for arguments "--disable-terminal" and "--disable-smapi".
Summary of commands:
--disable-terminal Stops the launch script from launching SMAPI with a terminal.
I used --disable-terminal since Mac/Linux use terminal.
--disable-smapi Makes the launcher launch the vanilla launcher which launches the vanilla game like normal.