### PR TITLE
Fix Load<T> not calling event if asset doesn't exist

### DIFF
--- a/src/StardewModdingAPI/Framework/SContentManager.cs
+++ b/src/StardewModdingAPI/Framework/SContentManager.cs
@@ -88,7 +88,12 @@ namespace StardewModdingAPI.Framework
                 return base.Load<T>(assetName);
 
             // intercept load
-            T data = base.Load<T>(assetName);
+            T data = default(T);
+            try {
+                data = base.Load<T>(assetName);
+            } catch (Exception) {
+                // Looks like the asset doesn't exist in the game's Content directory!
+            }
             string cacheLocale = this.GetCacheLocale(assetName, this.Cache);
             IContentEventHelper helper = new ContentEventHelper(cacheLocale, assetName, data, this.NormaliseAssetName);
             ContentEvents.InvokeAssetLoading(this.Monitor, helper);


### PR DESCRIPTION
Not sure if this works or not since I just kinda threw it together in the GitHub text editor, but this should make Load<T> not throw an error if the asset doesn't exist in the game's Content directory, but instead pass default(T) to the event handlers and return the default value. This won't make it throw an error if nothing handles the asset though, but I'm not sure there's an easy fix for that.