### PR TITLE
smapi.io log parser- Also close popups with mouse and escape key

### DIFF
--- a/src/SMAPI.Web/wwwroot/Content/js/log-parser.js
+++ b/src/SMAPI.Web/wwwroot/Content/js/log-parser.js
@@ -37,6 +37,14 @@ smapi.logParser = function(sectionUrl, pasteID) {
         $("#input").val("");
         $("#popup-upload").fadeIn();
     });
+
+    var closeUploadPopUp = function () {
+        $("#popup-upload").fadeOut(400, function () {
+            $("#input").val(memory);
+            memory = "";
+        });
+    };
+ 
     $("#popup-upload").on({
         'dragover dragenter': function(e) {
             e.preventDefault();
@@ -58,6 +66,10 @@ smapi.logParser = function(sectionUrl, pasteID) {
                 }, this, file, $("#input"));
                 reader.readAsText(file);
             }
+        },
+        'click': function (e) {
+            if (e.target.id === "popup-upload")
+                closeUploadPopUp();
         }
     });
 
@@ -91,15 +103,24 @@ smapi.logParser = function(sectionUrl, pasteID) {
             $("#uploader").fadeOut();
         }
     });
-    $("#cancel").on("click", function() {
-        $("#popup-upload").fadeOut(400, function() {
-            $("#input").val(memory);
-            memory = "";
-        });
+
+    $(document).on("keydown", function (e) {
+        if (e.which == 27) {
+            closeUploadPopUp();
+            $("#popup-raw").fadeOut(400);
+        }
     });
+    $("#cancel").on("click", closeUploadPopUp);
+
     $("#closeraw").on("click", function() {
         $("#popup-raw").fadeOut(400);
     });
+
+    $("#popup-raw").on("click", function (e) {
+        if (e.target.id === "popup-raw")
+            $("#popup-raw").fadeOut(400);
+    });
+
     if (pasteID) {
         getData(pasteID);
     }

--- a/src/SMAPI.Web/wwwroot/Content/js/log-parser.js
+++ b/src/SMAPI.Web/wwwroot/Content/js/log-parser.js
@@ -117,8 +117,9 @@ smapi.logParser = function(sectionUrl, pasteID) {
     });
 
     $("#popup-raw").on("click", function (e) {
-        if (e.target.id === "popup-raw")
+        if (e.target.id === "popup-raw") {
             $("#popup-raw").fadeOut(400);
+        }
     });
 
     if (pasteID) {

--- a/src/SMAPI.Web/wwwroot/Content/js/log-parser.js
+++ b/src/SMAPI.Web/wwwroot/Content/js/log-parser.js
@@ -106,7 +106,10 @@ smapi.logParser = function(sectionUrl, pasteID) {
 
     $(document).on("keydown", function (e) {
         if (e.which == 27) {
-            closeUploadPopUp();
+            if ($("#popup-upload").css("display") !== "none" && $("#popup-upload").css("opacity") == 1) {
+                closeUploadPopUp();
+            }
+
             $("#popup-raw").fadeOut(400);
         }
     });


### PR DESCRIPTION
The upload and view raw popups can now also be closed by hitting the escape key or clicking outside of the main popup (on the grayed out portion of the window).

Tested with the upload popup but I couldn't test it with the raw popup - the method was exactly the same so I expect it to also work.

If anything needs to be changed please let me know!