### PR TITLE
ignore terminator when picking the shell, fixes #294

### DIFF
--- a/src/SMAPI/unix-launcher.sh
+++ b/src/SMAPI/unix-launcher.sh
@@ -62,7 +62,8 @@ else
     fi
 
     # open SMAPI in terminal
-    if $COMMAND x-terminal-emulator 2>/dev/null; then
+    # some terms (like terminator) have broken -e: https://bugs.launchpad.net/terminator/+bug/1458137 ignore it
+    if $COMMAND x-terminal-emulator 2>/dev/null &&  x-terminal-emulator -v |grep -q -v 'terminator'; then
         x-terminal-emulator -e "$LAUNCHER"
     elif $COMMAND xfce4-terminal 2>/dev/null; then
         xfce4-terminal -e "$LAUNCHER"


### PR DESCRIPTION
-e is bugged and author of terminator refuses to fix it: https://bugs.launchpad.net/terminator/+bug/1458137

That should work exactly like before, just ignore terminator when looking for suitable term emulator