### PR TITLE
 If terminator found skip x-terminal-emulator and use custom launch.

### DIFF
--- a/src/SMAPI/unix-launcher.sh
+++ b/src/SMAPI/unix-launcher.sh
@@ -61,12 +61,12 @@ else
         COMMAND="type"
     fi
 
-    # open SMAPI in terminal
-	# special patch for terminator since it behaves odd with x-terminal-emulator "-e"
-	if $COMMAND terminator 2>/dev/null; then
-        terminator -e "$LAUNCHER"
-    elif $COMMAND x-terminal-emulator 2>/dev/null; then
+	# open SMAPI in terminal
+	# special patch for terminator since it behaves odd with x-terminal-emulator -e and speechmarks.
+    if $COMMAND x-terminal-emulator 2>/dev/null && x-terminal-emulator -v | grep -q -v 'terminator'; then
         x-terminal-emulator -e "$LAUNCHER"
+	elif $COMMAND terminator 2>/dev/null; then
+		terminator -e "$LAUNCHER"
     elif $COMMAND xfce4-terminal 2>/dev/null; then
         xfce4-terminal -e "$LAUNCHER"
     elif $COMMAND gnome-terminal 2>/dev/null; then

--- a/src/SMAPI/unix-launcher.sh
+++ b/src/SMAPI/unix-launcher.sh
@@ -62,7 +62,10 @@ else
     fi
 
     # open SMAPI in terminal
-    if $COMMAND x-terminal-emulator 2>/dev/null; then
+	# special patch for terminator since it behaves odd with x-terminal-emulator "-e"
+	if $COMMAND terminator 2>/dev/null; then
+        terminator -e "$LAUNCHER"
+    elif $COMMAND x-terminal-emulator 2>/dev/null; then
         x-terminal-emulator -e "$LAUNCHER"
     elif $COMMAND xfce4-terminal 2>/dev/null; then
         xfce4-terminal -e "$LAUNCHER"


### PR DESCRIPTION
Terminator runs fine with `terminator -e "$LAUNCHER"` however it doesn't like being called with `x-terminal-emulator -e "$LAUNCHER"`. It seems the speech marks mess with ` x-terminator-emulator`. I think terminator overrides `x-terminator-emulator` with a python script. Anyway this patch will check if terminator is in use and use a custom launch method for it. This is a mixture of my patch and https://github.com/Pathoschild/SMAPI/pull/418/commits/e912cb55cbf6e9a71f9187aa407c2ae69da62289 to create a better patch which will use terminator instead of just ignoring it.