### PR TITLE
Fix terminator in unix-launcher simple way.

### DIFF
--- a/src/SMAPI/unix-launcher.sh
+++ b/src/SMAPI/unix-launcher.sh
@@ -61,12 +61,12 @@ else
         COMMAND="type"
     fi
 
-    # open SMAPI in terminal
-	# special patch for terminator since it behaves odd with x-terminal-emulator "-e"
-	if $COMMAND terminator 2>/dev/null; then
-        terminator -e "$LAUNCHER"
-    elif $COMMAND x-terminal-emulator 2>/dev/null; then
+	# open SMAPI in terminal
+	# special patch for terminator since it behaves odd with x-terminal-emulator -e and speechmarks.
+    if $COMMAND x-terminal-emulator 2>/dev/null && x-terminal-emulator -v | grep -q -v 'terminator'; then
         x-terminal-emulator -e "$LAUNCHER"
+	elif $COMMAND terminator 2>/dev/null; then
+		terminator -e "$LAUNCHER"
     elif $COMMAND xfce4-terminal 2>/dev/null; then
         xfce4-terminal -e "$LAUNCHER"
     elif $COMMAND gnome-terminal 2>/dev/null; then

--- a/src/SMAPI/unix-launcher.sh
+++ b/src/SMAPI/unix-launcher.sh
@@ -61,12 +61,9 @@ else
         COMMAND="type"
     fi
 
-	# open SMAPI in terminal
-	# special patch for terminator since it behaves odd with x-terminal-emulator -e and speechmarks.
-    if $COMMAND x-terminal-emulator 2>/dev/null && x-terminal-emulator -v | grep -q -v 'terminator'; then
-        x-terminal-emulator -e "$LAUNCHER"
-	elif $COMMAND terminator 2>/dev/null; then
-		terminator -e "$LAUNCHER"
+    # open SMAPI in terminal
+    if $COMMAND x-terminal-emulator 2>/dev/null; then
+        x-terminal-emulator -e $LAUNCHER # remove speechmarks so terminator works
     elif $COMMAND xfce4-terminal 2>/dev/null; then
         xfce4-terminal -e "$LAUNCHER"
     elif $COMMAND gnome-terminal 2>/dev/null; then

--- a/src/SMAPI/unix-launcher.sh
+++ b/src/SMAPI/unix-launcher.sh
@@ -62,7 +62,10 @@ else
     fi
 
     # open SMAPI in terminal
-    if $COMMAND x-terminal-emulator 2>/dev/null; then
+	# special patch for terminator since it behaves odd with x-terminal-emulator "-e"
+	if $COMMAND terminator 2>/dev/null; then
+        terminator -e "$LAUNCHER"
+    elif $COMMAND x-terminal-emulator 2>/dev/null; then
         x-terminal-emulator -e "$LAUNCHER"
     elif $COMMAND xfce4-terminal 2>/dev/null; then
         xfce4-terminal -e "$LAUNCHER"


### PR DESCRIPTION
This is the simpler fix which should work for all systems. The only issue I could see here is something in $@ containing a space. But I don't think we would run into that situation here. No issues from the testing I have done so far.