### PR TITLE
Check if x-terminal-emulator is terminator

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -4,6 +4,7 @@
   * SMAPI now fixes curly quotes in `config.json` if possible.
   * Fixed semantic versions always ignoring `-0` tag.
   * Fixed rare issues caused by assembly references being incorrectly loaded twice.
+  * Fixed error on Linux loading SMAPI when the default terminal is set to Terminator.
 
 * For the [log parser][]:
   * Fixed parse error for logs with zero installed mods.

--- a/src/SMAPI/unix-launcher.sh
+++ b/src/SMAPI/unix-launcher.sh
@@ -63,7 +63,11 @@ else
 
     # open SMAPI in terminal
     if $COMMAND x-terminal-emulator 2>/dev/null; then
-        x-terminal-emulator -e "$LAUNCHER"
+        if [[ " $(readlink $(readlink /usr/bin/x-terminal-emulator))" == *"/terminator" ]]; then
+            terminator -e "$LAUNCHER"
+        else
+            x-terminal-emulator -e "$LAUNCHER"
+        fi
     elif $COMMAND xfce4-terminal 2>/dev/null; then
         xfce4-terminal -e "$LAUNCHER"
     elif $COMMAND gnome-terminal 2>/dev/null; then

--- a/src/SMAPI/unix-launcher.sh
+++ b/src/SMAPI/unix-launcher.sh
@@ -63,7 +63,10 @@ else
 
     # open SMAPI in terminal
     if $COMMAND x-terminal-emulator 2>/dev/null; then
-        if [[ " $(readlink $(readlink /usr/bin/x-terminal-emulator))" == *"/terminator" ]]; then
+        # Terminator converts -e to -x when used through x-terminal-emulator for some reason (per
+        # `man terminator`), which causes an "unable to find shell" error. If x-terminal-emulator
+        # is mapped to Terminator, invoke it directly instead.
+        if [[ "$(readlink -e $(which x-terminal-emulator))" == *"/terminator" ]]; then
             terminator -e "$LAUNCHER"
         else
             x-terminal-emulator -e "$LAUNCHER"


### PR DESCRIPTION
This pull request is meant to fix #294 it just checks what x-terminal-terminal links to (which should be: "/etc/alternatives/x-terminal-emulator") which in turn links to the executable of the shell set in update-alternatives.