### PR TITLE
move `xterm` to top of terminal checking order

### DIFF
--- a/src/SMAPI.Installer/unix-launcher.sh
+++ b/src/SMAPI.Installer/unix-launcher.sh
@@ -71,12 +71,12 @@ else
         else
             x-terminal-emulator -e "$LAUNCHER"
         fi
+    elif $COMMAND xterm 2>/dev/null; then
+        xterm -e "$LAUNCHER"
     elif $COMMAND xfce4-terminal 2>/dev/null; then
         xfce4-terminal -e "$LAUNCHER"
     elif $COMMAND gnome-terminal 2>/dev/null; then
         gnome-terminal -e "$LAUNCHER"
-    elif $COMMAND xterm 2>/dev/null; then
-        xterm -e "$LAUNCHER"
     elif $COMMAND konsole 2>/dev/null; then
         konsole -e "$LAUNCHER"
     elif $COMMAND terminal 2>/dev/null; then


### PR DESCRIPTION
Makes more sense, as `xterm` is much more common than any of the others and we only need a barebones terminal anyway. This also solves errors caused by issues such as https://github.com/mono/mono/issues/6752