### PR TITLE
Add overload to the player_add console command to add items by name

### DIFF
--- a/src/SMAPI.Mods.ConsoleCommands/Framework/Commands/Player/AddCommand.cs
+++ b/src/SMAPI.Mods.ConsoleCommands/Framework/Commands/Player/AddCommand.cs
@@ -65,6 +65,10 @@ namespace StardewModdingAPI.Mods.ConsoleCommands.Framework.Commands.Player
             monitor.Log($"OK, added {match.Name} ({match.Type} #{match.ID}) to your inventory.", LogLevel.Info);
         }
 
+        /*********
+        ** Private methods
+        *********/
+
         /// <summary>
         /// Finds a matching item by item type and id.
         /// </summary>
@@ -128,9 +132,6 @@ namespace StardewModdingAPI.Mods.ConsoleCommands.Framework.Commands.Player
             }
         }
 
-        /*********
-        ** Private methods
-        *********/
         private static string GetDescription()
         {
             string[] typeValues = Enum.GetNames(typeof(ItemType));

--- a/src/SMAPI.Mods.ConsoleCommands/Framework/Commands/Player/AddCommand.cs
+++ b/src/SMAPI.Mods.ConsoleCommands/Framework/Commands/Player/AddCommand.cs
@@ -118,16 +118,17 @@ namespace StardewModdingAPI.Mods.ConsoleCommands.Framework.Commands.Player
 
             // find matching items
             IEnumerable<SearchableItem> matching = this.Items.GetAll().Where(p => p.DisplayName.IndexOf(name, StringComparison.InvariantCultureIgnoreCase) != -1);
-            SearchableItem exactMatch = matching.FirstOrDefault(item => item.DisplayName.Equals(name, StringComparison.InvariantCultureIgnoreCase));
+            match = matching.FirstOrDefault(item => item.DisplayName.Equals(name, StringComparison.InvariantCultureIgnoreCase));
+
+            // handle unique requirement
+            if (match != null)
+            {
+                return;
+            }
 
             int numberOfMatches = matching.Count();
 
-            // handle unique requirement
-            if (exactMatch != null)
-            {
-                match = matching.ElementAt(0);
-            }
-            else if (numberOfMatches == 0)
+            if (numberOfMatches == 0)
             {
                 monitor.Log($"There's no item with name '{name}'. You can use the 'list_items [name]' command to search for items.", LogLevel.Error);
             }

--- a/src/SMAPI.Mods.ConsoleCommands/Framework/Commands/Player/AddCommand.cs
+++ b/src/SMAPI.Mods.ConsoleCommands/Framework/Commands/Player/AddCommand.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using StardewModdingAPI.Mods.ConsoleCommands.Framework.ItemData;
 using StardewValley;
@@ -30,24 +31,25 @@ namespace StardewModdingAPI.Mods.ConsoleCommands.Framework.Commands.Player
         /// <param name="args">The command arguments.</param>
         public override void Handle(IMonitor monitor, string command, ArgumentParser args)
         {
-            // read arguments
-            if (!args.TryGet(0, "item type", out string rawType, oneOf: Enum.GetNames(typeof(ItemType))))
-                return;
-            if (!args.TryGetInt(1, "item ID", out int id, min: 0))
-                return;
-            if (!args.TryGetInt(2, "count", out int count, min: 1, required: false))
-                count = 1;
-            if (!args.TryGetInt(3, "quality", out int quality, min: Object.lowQuality, max: Object.bestQuality, required: false))
-                quality = Object.lowQuality;
-            ItemType type = (ItemType)Enum.Parse(typeof(ItemType), rawType, ignoreCase: true);
+            SearchableItem match;
+            int optionalArgStartIndex;
 
-            // find matching item
-            SearchableItem match = this.Items.GetAll().FirstOrDefault(p => p.Type == type && p.ID == id);
-            if (match == null)
-            {
-                monitor.Log($"There's no {type} item with ID {id}.", LogLevel.Error);
+            if (!args.TryGet(0, "item type or name", out string typeOrName, required: true))
                 return;
-            }
+
+            // read arguments
+            if (Enum.GetNames(typeof(ItemType)).Contains(typeOrName, StringComparer.InvariantCultureIgnoreCase))
+                this.FindItemByTypeAndId(monitor, args, typeOrName, out optionalArgStartIndex, out match);
+            else
+                this.FindItemByName(monitor, args, typeOrName, out optionalArgStartIndex, out match);
+          
+            if (match == null)
+                return;
+
+            if (!args.TryGetInt(optionalArgStartIndex, "count", out int count, min: 1, required: false))
+                count = 1;
+            if (!args.TryGetInt(optionalArgStartIndex + 1, "quality", out int quality, min: Object.lowQuality, max: Object.bestQuality, required: false))
+                quality = Object.lowQuality;
 
             // apply count
             match.Item.Stack = count;
@@ -63,6 +65,69 @@ namespace StardewModdingAPI.Mods.ConsoleCommands.Framework.Commands.Player
             monitor.Log($"OK, added {match.Name} ({match.Type} #{match.ID}) to your inventory.", LogLevel.Info);
         }
 
+        /// <summary>
+        /// Finds a matching item by item type and id.
+        /// </summary>
+        /// <param name="monitor">Writes messages to the console and log file.</param>
+        /// <param name="args">The command arguments.</param>
+        /// <param name="rawType">The raw item type.</param>
+        /// <param name="nextArgIndex">The index of subsequent arguments.</param>
+        /// <param name="match">The matching item.</param>
+        private void FindItemByTypeAndId(IMonitor monitor, ArgumentParser args, string rawType, out int nextArgIndex, out SearchableItem match)
+        {
+            match = null;
+            nextArgIndex = 2;
+
+            // read arguments
+            if (!args.TryGetInt(1, "item ID", out int id, min: 0))
+                return;
+
+            ItemType type = (ItemType)Enum.Parse(typeof(ItemType), rawType, ignoreCase: true);
+
+            // find matching item
+            match = this.Items.GetAll().FirstOrDefault(p => p.Type == type && p.ID == id);
+
+            if (match == null)
+            {
+                monitor.Log($"There's no {type} item with ID {id}.", LogLevel.Error);
+            }
+        }
+
+        /// <summary>
+        /// Finds a matching item by name.
+        /// </summary>
+        /// <param name="monitor">Writes messages to the console and log file.</param>
+        /// <param name="args">The command arguments.</param>
+        /// <param name="name">The item name.</param>
+        /// <param name="nextArgIndex">The index of subsequent arguments.</param>
+        /// <param name="match">The matching item.</param>
+        private void FindItemByName(IMonitor monitor, ArgumentParser args, string name, out int nextArgIndex, out SearchableItem match)
+        {
+            match = null;
+            nextArgIndex = 1;
+
+            // interpret names with underscores as spaces
+            name = name.Replace('_', ' ');
+
+            // find matching items
+            IEnumerable<SearchableItem> matching = this.Items.GetAll().Where(p => p.DisplayName.Equals(name, StringComparison.CurrentCultureIgnoreCase));
+            int numberOfMatches = matching.Count();
+
+            // handle unique requirement
+            if (numberOfMatches == 0)
+            {
+                monitor.Log($"There's no item with name {name}.", LogLevel.Error);
+            }
+            else if (numberOfMatches == 1)
+            {
+                match = matching.ElementAt(0);
+            }
+            else
+            {
+                monitor.Log($"There are {numberOfMatches} items with name {name}. Try specifying a type and id instead.", LogLevel.Error);
+            }
+        }
+
         /*********
         ** Private methods
         *********/
@@ -71,9 +136,10 @@ namespace StardewModdingAPI.Mods.ConsoleCommands.Framework.Commands.Player
             string[] typeValues = Enum.GetNames(typeof(ItemType));
             return "Gives the player an item.\n"
                 + "\n"
-                + "Usage: player_add <type> <item> [count] [quality]\n"
+                + "Usage: player_add (<type> <item>|<name>) [count] [quality]\n"
                 + $"- type: the item type (one of {string.Join(", ", typeValues)}).\n"
                 + "- item: the item ID (use the 'list_items' command to see a list).\n"
+                + "- name: the display name of the item (only if there is exactly one such item).\n"
                 + "- count (optional): how many of the item to give.\n"
                 + $"- quality (optional): one of {Object.lowQuality} (normal), {Object.medQuality} (silver), {Object.highQuality} (gold), or {Object.bestQuality} (iridium).\n"
                 + "\n"

--- a/src/SMAPI.Mods.ConsoleCommands/Framework/Commands/Player/AddCommand.cs
+++ b/src/SMAPI.Mods.ConsoleCommands/Framework/Commands/Player/AddCommand.cs
@@ -32,6 +32,13 @@ namespace StardewModdingAPI.Mods.ConsoleCommands.Framework.Commands.Player
         /// <param name="args">The command arguments.</param>
         public override void Handle(IMonitor monitor, string command, ArgumentParser args)
         {
+            // validate
+            if (!Context.IsWorldReady)
+            {
+                monitor.Log("You need to load a save to use this command.", LogLevel.Error);
+                return;
+            }
+
             SearchableItem match;
 
             //read arguments
@@ -111,16 +118,22 @@ namespace StardewModdingAPI.Mods.ConsoleCommands.Framework.Commands.Player
 
             // find matching items
             IEnumerable<SearchableItem> matching = this.Items.GetAll().Where(p => p.DisplayName.IndexOf(name, StringComparison.InvariantCultureIgnoreCase) != -1);
+            SearchableItem exactMatch = matching.FirstOrDefault(item => item.DisplayName.Equals(name, StringComparison.InvariantCultureIgnoreCase));
+
             int numberOfMatches = matching.Count();
 
             // handle unique requirement
-            if (numberOfMatches == 0)
+            if (exactMatch != null)
             {
-                monitor.Log($"There's no item with name {name}.", LogLevel.Error);
+                match = matching.ElementAt(0);
+            }
+            else if (numberOfMatches == 0)
+            {
+                monitor.Log($"There's no item with name '{name}'. You can use the 'list_items [name]' command to search for items.", LogLevel.Error);
             }
             else if (numberOfMatches == 1)
             {
-                match = matching.ElementAt(0);
+                monitor.Log($"There's no item with name '{name}'. Did you mean '{matching.ElementAt(0).DisplayName}'? If so, type 'player_add name {matching.ElementAt(0).DisplayName}'.", LogLevel.Error);
             }
             else
             {

--- a/src/SMAPI.Mods.ConsoleCommands/Framework/Commands/Player/AddCommand.cs
+++ b/src/SMAPI.Mods.ConsoleCommands/Framework/Commands/Player/AddCommand.cs
@@ -16,6 +16,7 @@ namespace StardewModdingAPI.Mods.ConsoleCommands.Framework.Commands.Player
         /// <summary>Provides methods for searching and constructing items.</summary>
         private readonly ItemRepository Items = new ItemRepository();
 
+        /// <summary>All possible item types along with Name.</summary>
         private readonly string[] ItemTypeAndName = Enum.GetNames(typeof(ItemType)).Union(new string[] { "Name" }).ToArray();
 
         /*********
@@ -75,9 +76,7 @@ namespace StardewModdingAPI.Mods.ConsoleCommands.Framework.Commands.Player
         ** Private methods
         *********/
 
-        /// <summary>
-        /// Finds a matching item by item type and id.
-        /// </summary>
+        /// <summary>Finds a matching item by item type and id.</summary>
         /// <param name="monitor">Writes messages to the console and log file.</param>
         /// <param name="args">The command arguments.</param>
         /// <param name="rawType">The raw item type.</param>
@@ -101,9 +100,7 @@ namespace StardewModdingAPI.Mods.ConsoleCommands.Framework.Commands.Player
             }
         }
 
-        /// <summary>
-        /// Finds a matching item by name.
-        /// </summary>
+        /// <summary>Finds a matching item by name.</summary>
         /// <param name="monitor">Writes messages to the console and log file.</param>
         /// <param name="args">The command arguments.</param>
         /// <param name="name">The item name.</param>

--- a/src/SMAPI/Framework/CommandManager.cs
+++ b/src/SMAPI/Framework/CommandManager.cs
@@ -72,7 +72,7 @@ namespace StardewModdingAPI.Framework
             if (string.IsNullOrWhiteSpace(input))
                 return false;
 
-            string[] args = input.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            string[] args = this.ParseArgs(input);
             string name = args[0];
             args = args.Skip(1).ToArray();
 
@@ -103,6 +103,32 @@ namespace StardewModdingAPI.Framework
         /*********
         ** Private methods
         *********/
+        /// <summary>
+        /// Parses a string into an array of arguments.
+        /// </summary>
+        /// <param name="input">The string to parse.</param>
+        private string[] ParseArgs(string input)
+        {
+            bool inQuotes = false;
+            IList<string> args = new List<string>();
+            IList<char> currentArg = new List<char>();
+            foreach (char c in input)
+            {
+                if (c == '"')
+                {
+                    inQuotes = !inQuotes;
+                }
+                else if (!inQuotes && char.IsWhiteSpace(c))
+                {
+                    args.Add(string.Concat(currentArg));
+                    currentArg.Clear();
+                }
+                else
+                    currentArg.Add(c);
+            }
+            return args.Where(item => !string.IsNullOrWhiteSpace(item)).ToArray();
+        }
+
         /// <summary>Get a normalised command name.</summary>
         /// <param name="name">The command name.</param>
         private string GetNormalisedName(string name)

--- a/src/SMAPI/Framework/CommandManager.cs
+++ b/src/SMAPI/Framework/CommandManager.cs
@@ -126,6 +126,9 @@ namespace StardewModdingAPI.Framework
                 else
                     currentArg.Add(c);
             }
+
+            args.Add(string.Concat(currentArg));
+
             return args.Where(item => !string.IsNullOrWhiteSpace(item)).ToArray();
         }
 


### PR DESCRIPTION
This PR modifies the player_add command to effectively allow `<type> <id>` to be replaced with `<name>`. Items are looked up by name if the first argument to the command is not an `ItemType`. When looking up items by name, the command only succeeds if there is exactly one such item across all `ItemType`s.

Some things to consider:
  - I compared with the Item's `DisplayName` only. Would users ever want to compare with SDV's internal name?
  - I added error output which I think is clear, but the usage description change may not be so clear.
  - As a hacky way to support adding an item with spaces in its name, when looking up an item by name underscores are replaced with spaces. As of now this is undocumented and will conflict if any in game items actually have underscores in their name. Maybe this should just be removed entirely.

Feel free to comment and ask for changes.