### PR TITLE
Installer looks for more paths, also saves last user picked one

### DIFF
--- a/src/SMAPI/Program.cs
+++ b/src/SMAPI/Program.cs
@@ -10,6 +10,7 @@ using System.Runtime.ExceptionServices;
 using System.Security;
 using System.Text.RegularExpressions;
 using System.Threading;
+using Microsoft.Win32;
 #if SMAPI_FOR_WINDOWS
 using System.Windows.Forms;
 #endif
@@ -175,6 +176,8 @@ namespace StardewModdingAPI
         [HandleProcessCorruptedStateExceptions, SecurityCritical] // let try..catch handle corrupted state exceptions
         public void RunInteractively()
         {
+            this.EnsureRegistryPath();
+
             // initialise SMAPI
             try
             {
@@ -378,6 +381,64 @@ namespace StardewModdingAPI
                     ? $"Oops! You're running Stardew Valley {Constants.GameVersion}, but the oldest supported version is {Constants.MinimumGameVersion}. Please update your game before using SMAPI."
                     : "Oops! SMAPI doesn't seem to be compatible with your game. Make sure you're running the latest version of Stardew Valley and SMAPI."
                 );
+            }
+        }
+
+        /// <summary>
+        /// Adds current installation path into Windows registry for easier updating.
+        /// </summary>
+        private void EnsureRegistryPath()
+        {
+            if (Constants.Platform == Platform.Windows)
+            {
+                try
+                {
+                    var key = "Software/SMAPI";
+                    var name = "InstallPaths";
+
+                    RegistryKey currentuser = Environment.Is64BitOperatingSystem ? RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Registry64) : Registry.CurrentUser;
+                    RegistryKey openKey = currentuser.OpenSubKey(key);
+                    if (openKey == null)
+                    {
+                        openKey = currentuser;
+                        var keys = key.Split('\\');
+                        openKey = keys.Aggregate(openKey, (current, k) => current.CreateSubKey(k));
+                    }
+
+                    List<string> paths = new List<string>();
+                    var result = openKey.GetValue(name, null);
+                    if (!string.IsNullOrEmpty(name))
+                    {
+                        if (!name.Contains(";"))
+                        {
+                            paths = name.Split(';').ToList();
+                        }
+                        else
+                        {
+                            paths.Add(name);
+                        }
+                    }
+
+                    paths.Add(Constants.ExecutionPath);
+                    string executableFilename = EnvironmentUtility.GetExecutableName(Platform.Windows);
+                    var checkedPaths = (
+                            from path in paths.Distinct(StringComparer.InvariantCultureIgnoreCase)
+                            let dir = new DirectoryInfo(path)
+                            where dir.Exists && dir.EnumerateFiles(executableFilename).Any()
+                            select dir
+                        )
+                        .GroupBy(x => x.FullName) //adding duplicate paths check
+                        .Select(y => y.First());
+
+                    var res = checkedPaths.Aggregate("", (current, path) => current + path.FullName + ";").Trim(';');
+
+                    using (openKey)
+                        openKey.SetValue(name, res);
+                }
+                catch (Exception e)
+                {
+                    this.Monitor.Log($"SMAPI failed to insert its path in registry: {e.GetLogSummary()}", LogLevel.Warn);
+                }
             }
         }
 


### PR DESCRIPTION
I was frustrated of installer asking me for a path every single time I try to update SMAPI. My setup is a Steam folder copied from another computer, so it has no install info for Stardew Valley. Rewrote logic a bit to allow finding folder through Steam path (getting Steam install path from HKCU), also saving user-chosen path to HKCU and getting it on subsequent installs. Also, rebuilt path checking logic a bit to ensure that user is not presented with duplicate paths.