### PR TITLE
Change konsole launch options for newer ncurses

### DIFF
--- a/src/SMAPI.Installer/unix-launcher.sh
+++ b/src/SMAPI.Installer/unix-launcher.sh
@@ -78,7 +78,7 @@ else
     elif $COMMAND gnome-terminal 2>/dev/null; then
         gnome-terminal -e "$LAUNCHER"
     elif $COMMAND konsole 2>/dev/null; then
-        konsole -e "$LAUNCHER"
+        konsole -p Environment=TERM=xterm -e "$LAUNCHER"
     elif $COMMAND terminal 2>/dev/null; then
         terminal -e "$LAUNCHER"
     else


### PR DESCRIPTION
This makes konsole tell mono that it is xterm, allowing it to avoid mono/mono#6752 and providing a workaround for #489.