### PR TITLE
[Console Commands] Add command finds item by name when there is exactly one exact match

### DIFF
--- a/src/SMAPI.Mods.ConsoleCommands/Framework/Commands/Player/AddCommand.cs
+++ b/src/SMAPI.Mods.ConsoleCommands/Framework/Commands/Player/AddCommand.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using StardewModdingAPI.Mods.ConsoleCommands.Framework.ItemData;
 using StardewValley;

--- a/src/SMAPI.Mods.ConsoleCommands/Framework/Commands/Player/AddCommand.cs
+++ b/src/SMAPI.Mods.ConsoleCommands/Framework/Commands/Player/AddCommand.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using StardewModdingAPI.Mods.ConsoleCommands.Framework.ItemData;
 using StardewValley;
@@ -100,16 +101,18 @@ namespace StardewModdingAPI.Mods.ConsoleCommands.Framework.Commands.Player
 
             // find matching items
             SearchableItem[] matches = this.Items.GetAll().Where(p => p.NameContains(name)).ToArray();
+
+            // if exactly one item with the exact same name, use that item
+            SearchableItem[] exactNameMatches = matches.Where(p => p.NameEquivalentTo(name)).ToArray();
+            if (exactNameMatches.Length == 1)
+                return exactNameMatches[0];
+
             switch (matches.Length)
             {
                 // none found
                 case 0:
                     monitor.Log($"There's no item with name '{name}'. You can use the 'list_items [name]' command to search for items.", LogLevel.Error);
                     return null;
-
-                // exact match
-                case 1 when matches[0].NameEquivalentTo(name):
-                    return matches[0];
 
                 // list matches
                 default:


### PR DESCRIPTION
This makes the add command find an item by name if there is exactly one exact name match, as opposed to the current behavior of finding an item by name only if there is one contains match and that match is exact.

For example, this means that `player_add name coal` will add `coal` to the player's inventory instead of listing `coal` and `charcoal kiln`, but `player_add name stone` will still list all the `stone` variants.

If players want to lookup all items that contain `coal` in their name, they should use `list_items` instead.