### PR TITLE
Add version info to IModMetadata, Change update checks to consider preview versions

### DIFF
--- a/src/SMAPI/Framework/IModMetadata.cs
+++ b/src/SMAPI/Framework/IModMetadata.cs
@@ -80,14 +80,17 @@ namespace StardewModdingAPI.Framework
         /// <param name="api">The mod-provided API.</param>
         IModMetadata SetApi(object api);
 
-        /// <summary>Set the update status, indicating no errors happened.</summary>
+        /// <summary>Set the update version.</summary>
         /// <param name="latestVersion">The latest version.</param>
-        /// <param name="latestPreviewVersion">The latest preview version.</param>
-        IModMetadata SetUpdateStatus(ISemanticVersion latestVersion, ISemanticVersion latestPreviewVersion);
+        IModMetadata SetUpdateVersion(ISemanticVersion latestVersion);
 
-        /// <summary>Set the update status, indicating an error happened.</summary>
-        /// <param name="updateCheckError">The error checking for updates, if any.</param>
-        IModMetadata SetUpdateStatus(string updateCheckError);
+        /// <summary>Set the preview update version.</summary>
+        /// <param name="latestPreviewVersion">The latest preview version.</param>
+        IModMetadata SetPreviewUpdateVersion(ISemanticVersion latestPreviewVersion);
+
+        /// <summary>Set the error that occured while checking for updates.</summary>
+        /// <param name="updateCheckError">The error checking for updates.</param>
+        IModMetadata SetUpdateError(string updateCheckError);
 
         /// <summary>Whether the mod manifest was loaded (regardless of whether the mod itself was loaded).</summary>
         bool HasManifest();

--- a/src/SMAPI/Framework/IModMetadata.cs
+++ b/src/SMAPI/Framework/IModMetadata.cs
@@ -1,5 +1,6 @@
 using StardewModdingAPI.Framework.ModData;
 using StardewModdingAPI.Framework.ModLoading;
+using StardewModdingAPI.Framework.ModUpdateChecking;
 
 namespace StardewModdingAPI.Framework
 {
@@ -45,14 +46,11 @@ namespace StardewModdingAPI.Framework
         /// <summary>Whether the mod is a content pack.</summary>
         bool IsContentPack { get; }
 
-        /// <summary>The latest version of the mod.</summary>
-        ISemanticVersion LatestVersion { get; }
+        /// <summary>The update status of this mod (if any).</summary>
+        ModUpdateStatus UpdateStatus { get; }
 
-        /// <summary>The latest preview version of the mod, if any.</summary>
-        ISemanticVersion LatestPreviewVersion { get; }
-
-        /// <summary>The error checking for updates for this mod, if any.</summary>
-        string UpdateCheckError { get; }
+        /// <summary>The preview update status of this mod (if any).</summary>
+        ModUpdateStatus PreviewUpdateStatus { get; }
 
         /*********
         ** Public methods
@@ -80,17 +78,13 @@ namespace StardewModdingAPI.Framework
         /// <param name="api">The mod-provided API.</param>
         IModMetadata SetApi(object api);
 
-        /// <summary>Set the update version.</summary>
-        /// <param name="latestVersion">The latest version.</param>
-        IModMetadata SetUpdateVersion(ISemanticVersion latestVersion);
+        /// <summary>Set the update status.</summary>
+        /// <param name="updateStatus">The mod update status.</param>
+        IModMetadata SetUpdateStatus(ModUpdateStatus updateStatus);
 
-        /// <summary>Set the preview update version.</summary>
-        /// <param name="latestPreviewVersion">The latest preview version.</param>
-        IModMetadata SetPreviewUpdateVersion(ISemanticVersion latestPreviewVersion);
-
-        /// <summary>Set the error that occured while checking for updates.</summary>
-        /// <param name="updateCheckError">The error checking for updates.</param>
-        IModMetadata SetUpdateError(string updateCheckError);
+        /// <summary>Set the preview update status.</summary>
+        /// <param name="previewUpdateStatus">The mod preview update status.</param>
+        IModMetadata SetPreviewUpdateStatus(ModUpdateStatus previewUpdateStatus);
 
         /// <summary>Whether the mod manifest was loaded (regardless of whether the mod itself was loaded).</summary>
         bool HasManifest();

--- a/src/SMAPI/Framework/IModMetadata.cs
+++ b/src/SMAPI/Framework/IModMetadata.cs
@@ -45,6 +45,14 @@ namespace StardewModdingAPI.Framework
         /// <summary>Whether the mod is a content pack.</summary>
         bool IsContentPack { get; }
 
+        /// <summary>The latest version of the mod.</summary>
+        ISemanticVersion LatestVersion { get; }
+
+        /// <summary>The latest preview version of the mod, if any.</summary>
+        ISemanticVersion LatestPreviewVersion { get; }
+
+        /// <summary>The error checking for updates for this mod, if any.</summary>
+        string UpdateCheckError { get; }
 
         /*********
         ** Public methods
@@ -71,6 +79,15 @@ namespace StardewModdingAPI.Framework
         /// <summary>Set the mod-provided API instance.</summary>
         /// <param name="api">The mod-provided API.</param>
         IModMetadata SetApi(object api);
+
+        /// <summary>Set the update status, indicating no errors happened.</summary>
+        /// <param name="latestVersion">The latest version.</param>
+        /// <param name="latestPreviewVersion">The latest preview version.</param>
+        IModMetadata SetUpdateStatus(ISemanticVersion latestVersion, ISemanticVersion latestPreviewVersion);
+
+        /// <summary>Set the update status, indicating an error happened.</summary>
+        /// <param name="updateCheckError">The error checking for updates, if any.</param>
+        IModMetadata SetUpdateStatus(string updateCheckError);
 
         /// <summary>Whether the mod manifest was loaded (regardless of whether the mod itself was loaded).</summary>
         bool HasManifest();

--- a/src/SMAPI/Framework/ModLoading/ModMetadata.cs
+++ b/src/SMAPI/Framework/ModLoading/ModMetadata.cs
@@ -124,19 +124,25 @@ namespace StardewModdingAPI.Framework.ModLoading
             return this;
         }
 
-        /// <summary>Set the update status.</summary>
+        /// <summary>Set the update version.</summary>
         /// <param name="latestVersion">The latest version.</param>
-        /// <param name="latestPreviewVersion">The latest preview version.</param>
-        public IModMetadata SetUpdateStatus(ISemanticVersion latestVersion, ISemanticVersion latestPreviewVersion)
+        public IModMetadata SetUpdateVersion(ISemanticVersion latestVersion)
         {
             this.LatestVersion = latestVersion;
+            return this;
+        }
+
+        /// <summary>Set the preview update version.</summary>
+        /// <param name="latestPreviewVersion">The latest preview version.</param>
+        public IModMetadata SetPreviewUpdateVersion(ISemanticVersion latestPreviewVersion)
+        {
             this.LatestPreviewVersion = latestPreviewVersion;
             return this;
         }
 
-        // <summary>Set the update status, indicating an error happened.</summary>
-        /// <param name="updateCheckError">The error checking for updates, if any.</param>
-        public IModMetadata SetUpdateStatus(string updateCheckError)
+        /// <summary>Set the error that occured while checking for updates.</summary>
+        /// <param name="updateCheckError">The error checking for updates.</param>
+        public IModMetadata SetUpdateError(string updateCheckError)
         {
             this.UpdateCheckError = updateCheckError;
             return this;

--- a/src/SMAPI/Framework/ModLoading/ModMetadata.cs
+++ b/src/SMAPI/Framework/ModLoading/ModMetadata.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using StardewModdingAPI.Framework.ModData;
+using StardewModdingAPI.Framework.ModUpdateChecking;
 
 namespace StardewModdingAPI.Framework.ModLoading
 {
@@ -43,14 +44,11 @@ namespace StardewModdingAPI.Framework.ModLoading
         /// <summary>The mod-provided API (if any).</summary>
         public object Api { get; private set; }
 
-        /// <summary>The latest version of the mod.</summary>
-        public ISemanticVersion LatestVersion { get; private set; }
+        /// <summary>The update status of this mod (if any).</summary>
+        public ModUpdateStatus UpdateStatus { get; private set; }
 
-        /// <summary>The latest preview version of the mod, if any.</summary>
-        public ISemanticVersion LatestPreviewVersion { get; private set; }
-
-        /// <summary>The error checking for updates for this mod, if any.</summary>
-        public string UpdateCheckError { get; private set; }
+        /// <summary>The preview update status of this mod (if any).</summary>
+        public ModUpdateStatus PreviewUpdateStatus { get; private set; }
 
         /// <summary>Whether the mod is a content pack.</summary>
         public bool IsContentPack => this.Manifest?.ContentPackFor != null;
@@ -124,27 +122,19 @@ namespace StardewModdingAPI.Framework.ModLoading
             return this;
         }
 
-        /// <summary>Set the update version.</summary>
-        /// <param name="latestVersion">The latest version.</param>
-        public IModMetadata SetUpdateVersion(ISemanticVersion latestVersion)
+        /// <summary>Set the update status.</summary>
+        /// <param name="updateStatus">The mod update status.</param>
+        public IModMetadata SetUpdateStatus(ModUpdateStatus updateStatus)
         {
-            this.LatestVersion = latestVersion;
+            this.UpdateStatus = updateStatus;
             return this;
         }
 
-        /// <summary>Set the preview update version.</summary>
-        /// <param name="latestPreviewVersion">The latest preview version.</param>
-        public IModMetadata SetPreviewUpdateVersion(ISemanticVersion latestPreviewVersion)
+        /// <summary>Set the preview update status.</summary>
+        /// <param name="previewUpdateStatus">The mod preview update status.</param>
+        public IModMetadata SetPreviewUpdateStatus(ModUpdateStatus previewUpdateStatus)
         {
-            this.LatestPreviewVersion = latestPreviewVersion;
-            return this;
-        }
-
-        /// <summary>Set the error that occured while checking for updates.</summary>
-        /// <param name="updateCheckError">The error checking for updates.</param>
-        public IModMetadata SetUpdateError(string updateCheckError)
-        {
-            this.UpdateCheckError = updateCheckError;
+            this.PreviewUpdateStatus = previewUpdateStatus;
             return this;
         }
 

--- a/src/SMAPI/Framework/ModLoading/ModMetadata.cs
+++ b/src/SMAPI/Framework/ModLoading/ModMetadata.cs
@@ -43,6 +43,15 @@ namespace StardewModdingAPI.Framework.ModLoading
         /// <summary>The mod-provided API (if any).</summary>
         public object Api { get; private set; }
 
+        /// <summary>The latest version of the mod.</summary>
+        public ISemanticVersion LatestVersion { get; private set; }
+
+        /// <summary>The latest preview version of the mod, if any.</summary>
+        public ISemanticVersion LatestPreviewVersion { get; private set; }
+
+        /// <summary>The error checking for updates for this mod, if any.</summary>
+        public string UpdateCheckError { get; private set; }
+
         /// <summary>Whether the mod is a content pack.</summary>
         public bool IsContentPack => this.Manifest?.ContentPackFor != null;
 
@@ -112,6 +121,24 @@ namespace StardewModdingAPI.Framework.ModLoading
         public IModMetadata SetApi(object api)
         {
             this.Api = api;
+            return this;
+        }
+
+        /// <summary>Set the update status.</summary>
+        /// <param name="latestVersion">The latest version.</param>
+        /// <param name="latestPreviewVersion">The latest preview version.</param>
+        public IModMetadata SetUpdateStatus(ISemanticVersion latestVersion, ISemanticVersion latestPreviewVersion)
+        {
+            this.LatestVersion = latestVersion;
+            this.LatestPreviewVersion = latestPreviewVersion;
+            return this;
+        }
+
+        // <summary>Set the update status, indicating an error happened.</summary>
+        /// <param name="updateCheckError">The error checking for updates, if any.</param>
+        public IModMetadata SetUpdateStatus(string updateCheckError)
+        {
+            this.UpdateCheckError = updateCheckError;
             return this;
         }
 

--- a/src/SMAPI/Framework/ModUpdateChecking/ModUpdateStatus.cs
+++ b/src/SMAPI/Framework/ModUpdateChecking/ModUpdateStatus.cs
@@ -28,5 +28,10 @@ namespace StardewModdingAPI.Framework.ModUpdateChecking
         {
             this.Error = error;
         }
+
+        /// <summary>Construct an instance.</summary>
+        public ModUpdateStatus()
+        {
+        }
     }
 }

--- a/src/SMAPI/Framework/ModUpdateChecking/ModUpdateStatus.cs
+++ b/src/SMAPI/Framework/ModUpdateChecking/ModUpdateStatus.cs
@@ -1,0 +1,32 @@
+namespace StardewModdingAPI.Framework.ModUpdateChecking
+{
+    /// <summary>Update status for a mod.</summary>
+    internal class ModUpdateStatus
+    {
+        /*********
+        ** Accessors
+        *********/
+        /// <summary>The version that this mod can be updated to (if any).</summary>
+        public ISemanticVersion Version { get; }
+
+        /// <summary>The error checking for updates of this mod (if any).</summary>
+        public string Error { get; }
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Construct an instance.</summary>
+        /// <param name="version">The version that this mod can be update to.</param>
+        public ModUpdateStatus(ISemanticVersion version)
+        {
+            this.Version = version;
+        }
+
+        /// <summary>Construct an instance.</summary>
+        /// <param name="error">The error checking for updates of this mod.</param>
+        public ModUpdateStatus(string error)
+        {
+            this.Error = error;
+        }
+    }
+}

--- a/src/SMAPI/Program.cs
+++ b/src/SMAPI/Program.cs
@@ -716,6 +716,14 @@ namespace StardewModdingAPI
                             }
                         }
 
+                        // set mods to have no updates
+                        foreach (IModMetadata mod in results.Select(item => item.Mod)
+                            .Where(item => !updatesByMod.ContainsKey(item)))
+                        {
+                            mod.SetUpdateStatus(new ModUpdateStatus());
+                            mod.SetPreviewUpdateStatus(new ModUpdateStatus());
+                        }
+
                         // output
                         if (updatesByMod.Any())
                         {

--- a/src/SMAPI/StardewModdingAPI.csproj
+++ b/src/SMAPI/StardewModdingAPI.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Framework\ContentManagers\IContentManager.cs" />
     <Compile Include="Framework\ContentManagers\ModContentManager.cs" />
     <Compile Include="Framework\Models\ModFolderExport.cs" />
+    <Compile Include="Framework\ModUpdateChecking\ModUpdateStatus.cs" />
     <Compile Include="Framework\Patching\GamePatcher.cs" />
     <Compile Include="Framework\Patching\IHarmonyPatch.cs" />
     <Compile Include="Framework\Serialisation\ColorConverter.cs" />


### PR DESCRIPTION
This pull request:
- Adds version status of the mod to `IModMetadata`, so that it can be retrieved by mods as a temporary measure until breaking mod registry changes are made. (#534)
  - This info is interpreted as:
    - If `IModMetadata.UpdateStatus` is null, the update check hasn't happened yet.
    - If `IModMetadata.UpdateStatus.Version` is null and `IModMetadata.UpdateStatus.Error` is null, there are no normal updates.
    - If `IModMetadata.UpdateStatus.Version` is not null, there is a normal update.
    - If `IModMetadata.UpdateStatus.Error` is not null, there was an error checking for a normal update.
  - The same logic applies to `IModMetadata.PreviewUpdateStatus`, but for preview updates.
  - `ModUpdateStatus.Version` and `ModUpdateStatus.Error` will never both be non-null.
- Changes SMAPI's update checking to consider preview versions:
  - If the local version is newer than the remote version but older than the remote preview version, the local version is considered a preview version. Update checking will look for the latest preview or non preview version to update to.
  - Otherwise, update checking will look for the latest non preview version to update to.

I would appreciate comments on how to improve these changes :)