### PR TITLE
Update readme.txt to work better with some text editors

### DIFF
--- a/src/SMAPI.Installer/readme.txt
+++ b/src/SMAPI.Installer/readme.txt
@@ -16,7 +16,7 @@ SMAPI lets you run Stardew Valley with mods. Don't forget to download mods separ
 
 Player's guide
 --------------------------------
-See https://stardewvalleywiki.com/Modding:Player_Guide.
+See https://stardewvalleywiki.com/Modding:Player_Guide
 
 
 Manual install
@@ -24,7 +24,7 @@ Manual install
 THIS IS NOT RECOMMENDED FOR MOST PLAYERS. See instructions above instead.
 If you really want to install SMAPI manually, here's how.
 
-1. Download the latest version of SMAPI: https://github.com/Pathoschild/SMAPI/releases.
+1. Download the latest version of SMAPI: https://github.com/Pathoschild/SMAPI/releases
 2. Unzip the .zip file somewhere (not in your game folder).
 3. Copy the files from the "internal/Windows" folder (on Windows) or "internal/Mono" folder (on
    Linux/Mac) into your game folder. The `StardewModdingAPI.exe` file should be right next to the


### PR DESCRIPTION
Some Text editors (such as Notepad++ and Sublime) allow you to click on a URL in a .txt file and then your default browser will navigate to it just fine. However, these same editors will sometimes get confused by a period at the end of a link and will add it, often leading to a 404.

This change simply removes the periods at the end of the two links in the text file allowing these readers to navigate properly.