### PR TITLE
Expand validation to respect CIL placeholders

### DIFF
--- a/src/SMAPI/Framework/ModLoading/Finders/ReferenceToMemberWithUnexpectedTypeFinder.cs
+++ b/src/SMAPI/Framework/ModLoading/Finders/ReferenceToMemberWithUnexpectedTypeFinder.cs
@@ -67,7 +67,8 @@ namespace StardewModdingAPI.Framework.ModLoading.Finders
                 // validate return type
                 string actualReturnTypeID = this.GetComparableTypeID(targetField.FieldType);
                 string expectedReturnTypeID = this.GetComparableTypeID(fieldRef.FieldType);
-                if (actualReturnTypeID != expectedReturnTypeID)
+
+                if (!RewriteHelper.LooksLikeSameType(expectedReturnTypeID, actualReturnTypeID))
                 {
                     this.NounPhrase = $"reference to {fieldRef.DeclaringType.FullName}.{fieldRef.Name} (field returns {this.GetFriendlyTypeName(targetField.FieldType, actualReturnTypeID)}, not {this.GetFriendlyTypeName(fieldRef.FieldType, expectedReturnTypeID)})";
                     return InstructionHandleResult.NotCompatible;
@@ -110,8 +111,8 @@ namespace StardewModdingAPI.Framework.ModLoading.Finders
         /// <param name="type">The type reference.</param>
         private bool ShouldValidate(TypeReference type)
         {
-            if (type == null)
-                return false;
+            if (type != null)
+                return true;
                 
             // Extract scope name from type string representation for compatibility
             // Under Linux, type.Scope.Name sometimes reports incorrectly

--- a/src/SMAPI/Framework/ModLoading/Finders/ReferenceToMemberWithUnexpectedTypeFinder.cs
+++ b/src/SMAPI/Framework/ModLoading/Finders/ReferenceToMemberWithUnexpectedTypeFinder.cs
@@ -110,6 +110,9 @@ namespace StardewModdingAPI.Framework.ModLoading.Finders
         /// <param name="type">The type reference.</param>
         private bool ShouldValidate(TypeReference type)
         {
+            if (type == null)
+                return false;
+                
             // Extract scope name from type string representation for compatibility
             // Under Linux, type.Scope.Name sometimes reports incorrectly
             string scopeName = type.ToString();
@@ -118,7 +121,7 @@ namespace StardewModdingAPI.Framework.ModLoading.Finders
 
             scopeName = scopeName.Substring(0, scopeName.IndexOf(".", System.StringComparison.CurrentCulture));
 
-            return type != null && this.ValidateReferencesToAssemblies.Contains(scopeName);
+            return this.ValidateReferencesToAssemblies.Contains(scopeName);
         }
 
         /// <summary>Get a unique string representation of a type.</summary>

--- a/src/SMAPI/Framework/ModLoading/Finders/ReferenceToMemberWithUnexpectedTypeFinder.cs
+++ b/src/SMAPI/Framework/ModLoading/Finders/ReferenceToMemberWithUnexpectedTypeFinder.cs
@@ -110,7 +110,15 @@ namespace StardewModdingAPI.Framework.ModLoading.Finders
         /// <param name="type">The type reference.</param>
         private bool ShouldValidate(TypeReference type)
         {
-            return type != null && this.ValidateReferencesToAssemblies.Contains(type.Scope.Name);
+            // Extract scope name from type string representation for compatibility
+            // Under Linux, type.Scope.Name sometimes reports incorrectly
+            string scopeName = type.ToString();
+            if (scopeName[0] != '$')
+                return false;
+
+            scopeName = scopeName.Substring(0, scopeName.IndexOf(".", System.StringComparison.CurrentCulture));
+
+            return type != null && this.ValidateReferencesToAssemblies.Contains(scopeName);
         }
 
         /// <summary>Get a unique string representation of a type.</summary>

--- a/src/SMAPI/Framework/ModLoading/Finders/ReferenceToMemberWithUnexpectedTypeFinder.cs
+++ b/src/SMAPI/Framework/ModLoading/Finders/ReferenceToMemberWithUnexpectedTypeFinder.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 
@@ -15,9 +14,6 @@ namespace StardewModdingAPI.Framework.ModLoading.Finders
         *********/
         /// <summary>The assembly names to which to heuristically detect broken references.</summary>
         private readonly HashSet<string> ValidateReferencesToAssemblies;
-
-        /// <summary>A pattern matching type name substrings to strip for display.</summary>
-        private readonly Regex StripTypeNamePattern = new Regex(@"`\d+(?=<)", RegexOptions.Compiled);
 
 
         /*********
@@ -65,12 +61,9 @@ namespace StardewModdingAPI.Framework.ModLoading.Finders
                     return InstructionHandleResult.None;
 
                 // validate return type
-                string actualReturnTypeID = this.GetComparableTypeID(targetField.FieldType);
-                string expectedReturnTypeID = this.GetComparableTypeID(fieldRef.FieldType);
-
-                if (!RewriteHelper.LooksLikeSameType(expectedReturnTypeID, actualReturnTypeID))
+                if (!RewriteHelper.LooksLikeSameType(fieldRef.FieldType, targetField.FieldType))
                 {
-                    this.NounPhrase = $"reference to {fieldRef.DeclaringType.FullName}.{fieldRef.Name} (field returns {this.GetFriendlyTypeName(targetField.FieldType, actualReturnTypeID)}, not {this.GetFriendlyTypeName(fieldRef.FieldType, expectedReturnTypeID)})";
+                    this.NounPhrase = $"reference to {fieldRef.DeclaringType.FullName}.{fieldRef.Name} (field returns {this.GetFriendlyTypeName(targetField.FieldType)}, not {this.GetFriendlyTypeName(fieldRef.FieldType)})";
                     return InstructionHandleResult.NotCompatible;
                 }
             }
@@ -92,10 +85,9 @@ namespace StardewModdingAPI.Framework.ModLoading.Finders
                     return InstructionHandleResult.NotCompatible;
                 }
 
-                string expectedReturnType = this.GetComparableTypeID(methodDef.ReturnType);
-                if (candidateMethods.All(method => !RewriteHelper.LooksLikeSameType(this.GetComparableTypeID(method.ReturnType), expectedReturnType)))
+                if (candidateMethods.All(method => !RewriteHelper.LooksLikeSameType(method.ReturnType, methodDef.ReturnType)))
                 {
-                    this.NounPhrase = $"reference to {methodDef.DeclaringType.FullName}.{methodDef.Name} (no such method returns {this.GetFriendlyTypeName(methodDef.ReturnType, expectedReturnType)})";
+                    this.NounPhrase = $"reference to {methodDef.DeclaringType.FullName}.{methodDef.Name} (no such method returns {this.GetFriendlyTypeName(methodDef.ReturnType)})";
                     return InstructionHandleResult.NotCompatible;
                 }
             }
@@ -114,17 +106,9 @@ namespace StardewModdingAPI.Framework.ModLoading.Finders
             return type != null && this.ValidateReferencesToAssemblies.Contains(type.Scope.Name);
         }
 
-        /// <summary>Get a unique string representation of a type.</summary>
-        /// <param name="type">The type reference.</param>
-        private string GetComparableTypeID(TypeReference type)
-        {
-            return this.StripTypeNamePattern.Replace(type.FullName, "");
-        }
-
         /// <summary>Get a shorter type name for display.</summary>
         /// <param name="type">The type reference.</param>
-        /// <param name="typeID">The comparable type ID from <see cref="GetComparableTypeID"/>.</param>
-        private string GetFriendlyTypeName(TypeReference type, string typeID)
+        private string GetFriendlyTypeName(TypeReference type)
         {
             // most common built-in types
             switch (type.FullName)
@@ -141,10 +125,10 @@ namespace StardewModdingAPI.Framework.ModLoading.Finders
             foreach (string @namespace in new[] { "Microsoft.Xna.Framework", "Netcode", "System", "System.Collections.Generic" })
             {
                 if (type.Namespace == @namespace)
-                    return typeID.Substring(@namespace.Length + 1);
+                    return type.Name;
             }
 
-            return typeID;
+            return type.FullName;
         }
     }
 }

--- a/src/SMAPI/Framework/ModLoading/Finders/ReferenceToMemberWithUnexpectedTypeFinder.cs
+++ b/src/SMAPI/Framework/ModLoading/Finders/ReferenceToMemberWithUnexpectedTypeFinder.cs
@@ -93,7 +93,7 @@ namespace StardewModdingAPI.Framework.ModLoading.Finders
                 }
 
                 string expectedReturnType = this.GetComparableTypeID(methodDef.ReturnType);
-                if (candidateMethods.All(method => this.GetComparableTypeID(method.ReturnType) != expectedReturnType))
+                if (candidateMethods.All(method => !RewriteHelper.LooksLikeSameType(this.GetComparableTypeID(method.ReturnType), expectedReturnType)))
                 {
                     this.NounPhrase = $"reference to {methodDef.DeclaringType.FullName}.{methodDef.Name} (no such method returns {this.GetFriendlyTypeName(methodDef.ReturnType, expectedReturnType)})";
                     return InstructionHandleResult.NotCompatible;

--- a/src/SMAPI/Framework/ModLoading/Finders/ReferenceToMemberWithUnexpectedTypeFinder.cs
+++ b/src/SMAPI/Framework/ModLoading/Finders/ReferenceToMemberWithUnexpectedTypeFinder.cs
@@ -111,18 +111,7 @@ namespace StardewModdingAPI.Framework.ModLoading.Finders
         /// <param name="type">The type reference.</param>
         private bool ShouldValidate(TypeReference type)
         {
-            if (type != null)
-                return true;
-                
-            // Extract scope name from type string representation for compatibility
-            // Under Linux, type.Scope.Name sometimes reports incorrectly
-            string scopeName = type.ToString();
-            if (scopeName[0] != '$')
-                return false;
-
-            scopeName = scopeName.Substring(0, scopeName.IndexOf(".", System.StringComparison.CurrentCulture));
-
-            return this.ValidateReferencesToAssemblies.Contains(scopeName);
+            return type != null && this.ValidateReferencesToAssemblies.Contains(type.Scope.Name);
         }
 
         /// <summary>Get a unique string representation of a type.</summary>

--- a/src/SMAPI/Framework/ModLoading/RewriteHelper.cs
+++ b/src/SMAPI/Framework/ModLoading/RewriteHelper.cs
@@ -216,7 +216,6 @@ namespace StardewModdingAPI.Framework.ModLoading
                 if (symbolBoundaries.Contains(c))
                 {
                     bool match = RewriteHelper.SymbolsMatch(new SymbolLocation(symbol, depth), typeSymbols[symbolCount], placeholderMap);
-                    System.Console.Write($"match: {match}");
                     if (typeSymbols.Count <= symbolCount ||
                         !match)
                         return false;

--- a/src/SMAPI/Framework/ModLoading/RewriteHelper.cs
+++ b/src/SMAPI/Framework/ModLoading/RewriteHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Mono.Cecil;
@@ -89,6 +90,168 @@ namespace StardewModdingAPI.Framework.ModLoading
             return type
                 .GetMethods(BindingFlags.Instance | BindingFlags.DeclaredOnly | BindingFlags.Public)
                 .Any(method => RewriteHelper.HasMatchingSignature(method, reference));
+        }
+
+        /// <summary>Determine whether this type ID has a placeholder such as !0.</summary>
+        /// <param name="typeID">The type to check.</param>
+        /// <returns>true if the type ID contains a placeholder, false if not.</returns>
+        public static bool HasPlaceholder(string typeID)
+        {
+            return typeID.Contains("!0");
+        }
+
+        /// <summary> returns whether this type ID is a placeholder, i.e., it begins with "!".</summary>
+        /// <param name="symbol">The symbol to validate.</param>
+        /// <returns>true if the symbol is a placeholder, false if not</returns>
+        public static bool IsPlaceholder(string symbol)
+        {
+            return symbol.StartsWith("!");
+        }
+
+        /// <summary>Determine whether two type IDs look like the same type, accounting for placeholder values such as !0.</summary>
+        /// <param name="typeA">The type ID to compare.</param>
+        /// <param name="typeB">The other type ID to compare.</param>
+        /// <returns>true if the type IDs look like the same type, false if not.</returns>
+        public static bool LooksLikeSameType(string typeA, string typeB)
+        {
+            string placeholderType, actualType = "";
+
+            if (RewriteHelper.HasPlaceholder(typeA))
+            {
+                placeholderType = typeA;
+                actualType = typeB;
+            } else if (RewriteHelper.HasPlaceholder(typeB))
+            {
+                placeholderType = typeB;
+                actualType = typeA;
+            } else
+            {
+                return typeA == typeB;
+            }
+
+            return RewriteHelper.PlaceholderTypeValidates(placeholderType, actualType);
+        }
+
+        protected class SymbolLocation
+        {
+            public string symbol;
+            public int depth;
+
+            public SymbolLocation(string symbol, int depth)
+            {
+                this.symbol = symbol;
+                this.depth = depth;
+            }
+        }
+
+        private static List<char> symbolBoundaries = new List<char>{'<', '>', ','};
+
+        /// <summary> Traverses and parses out symbols from a type which does not contain placeholder values.</summary>
+        /// <param name="type">The type to traverse.</param>
+        /// <param name="typeSymbols">A List in which to store the parsed symbols.</param>
+        private static void TraverseActualType(string type, List<SymbolLocation> typeSymbols)
+        {
+            int depth = 0;
+            string symbol = "";
+
+            foreach (char c in type)
+            {
+                if (RewriteHelper.symbolBoundaries.Contains(c))
+                {
+                    typeSymbols.Add(new SymbolLocation(symbol, depth));
+                    symbol = "";
+                    switch (c) {
+                        case '<':
+                            depth++;
+                            break;
+                        case '>':
+                            depth--;
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                else
+                    symbol += c;
+            }
+        }
+
+        /// <summary> Determines whether two symbols in a type ID match, accounting for placeholders such as !0.</summary>
+        /// <param name="symbolA">A symbol in a typename which contains placeholders.</param>
+        /// <param name="symbolB">A symbol in a typename which does not contain placeholders.</param>
+        /// <param name="placeholderMap">A dictionary containing a mapping of placeholders to concrete types.</param>
+        /// <returns>true if the symbols match, false if not.</returns>
+        private static bool SymbolsMatch(SymbolLocation symbolA, SymbolLocation symbolB, Dictionary<string, string> placeholderMap)
+        {
+            System.Console.Write($"comparing {symbolA.symbol} at depth {symbolA.depth} to {symbolB.symbol} at {symbolB.depth}");
+            if (symbolA.depth != symbolB.depth)
+                return false;
+
+            if (!RewriteHelper.IsPlaceholder(symbolA.symbol)) {
+                return symbolA.symbol == symbolB.symbol;
+            }
+
+            if (placeholderMap.ContainsKey(symbolA.symbol))
+            {
+                return placeholderMap[symbolA.symbol] == symbolB.symbol;
+            }
+
+            placeholderMap[symbolA.symbol] = symbolB.symbol;
+
+            return true;
+        }
+
+        /// <summary> Determines whether a type which has placeholders correctly resolves to the concrete type provided. </summary>
+        /// <param name="type">A type containing placeholders such as !0.</param>
+        /// <param name="typeSymbols">The list of symbols extracted from the concrete type.</param>
+        /// <returns>true if the type resolves correctly, false if not.</returns>
+        private static bool PlaceholderTypeResolvesToActualType(string type, List<SymbolLocation> typeSymbols)
+        {
+            Dictionary<string, string> placeholderMap = new Dictionary<string, string>();
+
+            int depth = 0, symbolCount = 0;
+            string symbol = "";
+
+            foreach (char c in type)
+            {
+                if (symbolBoundaries.Contains(c))
+                {
+                    bool match = RewriteHelper.SymbolsMatch(new SymbolLocation(symbol, depth), typeSymbols[symbolCount], placeholderMap);
+                    System.Console.Write($"match: {match}");
+                    if (typeSymbols.Count <= symbolCount ||
+                        !match)
+                        return false;
+
+                    symbolCount++;
+                    symbol = "";
+                    switch (c)
+                    {
+                        case '<':
+                            depth++;
+                            break;
+                        case '>':
+                            depth--;
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                else
+                    symbol += c;
+            }
+
+            return true;
+        }
+
+        /// <summary>Determines whether a type with placeholders in it matches a type without placeholders.</summary>
+        /// <param name="placeholderType">The type with placeholders in it.</param>
+        /// <param name="actualType">The type without placeholders.</param>
+        /// <returns>true if the placeholder type can resolve to the actual type, false if not.</returns>
+        private static bool PlaceholderTypeValidates(string placeholderType, string actualType) {
+            List<SymbolLocation> typeSymbols = new List<SymbolLocation>();
+
+            RewriteHelper.TraverseActualType(actualType, typeSymbols);
+            return PlaceholderTypeResolvesToActualType(placeholderType, typeSymbols);
         }
     }
 }

--- a/src/SMAPI/Framework/ModLoading/RewriteHelper.cs
+++ b/src/SMAPI/Framework/ModLoading/RewriteHelper.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Text.RegularExpressions;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 
@@ -14,8 +12,8 @@ namespace StardewModdingAPI.Framework.ModLoading
         /*********
         ** Properties
         *********/
-        /// <summary>A pattern matching type name substrings to strip for display.</summary>
-        private static readonly Regex StripTypeNamePattern = new Regex(@"`\d+(?=<)", RegexOptions.Compiled);
+        /// <summary>The comparer which heuristically compares type definitions.</summary>
+        private static readonly TypeReferenceComparer TypeDefinitionComparer = new TypeReferenceComparer();
 
 
         /*********
@@ -68,6 +66,15 @@ namespace StardewModdingAPI.Framework.ModLoading
             return true;
         }
 
+        /// <summary>Determine whether two type IDs look like the same type, accounting for placeholder values such as !0.</summary>
+        /// <param name="typeA">The type ID to compare.</param>
+        /// <param name="typeB">The other type ID to compare.</param>
+        /// <returns>true if the type IDs look like the same type, false if not.</returns>
+        public static bool LooksLikeSameType(TypeReference typeA, TypeReference typeB)
+        {
+            return RewriteHelper.TypeDefinitionComparer.Equals(typeA, typeB);
+        }
+
         /// <summary>Get whether a method definition matches the signature expected by a method reference.</summary>
         /// <param name="definition">The method definition.</param>
         /// <param name="reference">The method reference.</param>
@@ -98,179 +105,6 @@ namespace StardewModdingAPI.Framework.ModLoading
             return type
                 .GetMethods(BindingFlags.Instance | BindingFlags.DeclaredOnly | BindingFlags.Public)
                 .Any(method => RewriteHelper.HasMatchingSignature(method, reference));
-        }
-
-        /// <summary>Determine whether this type ID has a placeholder such as !0.</summary>
-        /// <param name="typeID">The type to check.</param>
-        /// <returns>true if the type ID contains a placeholder, false if not.</returns>
-        public static bool HasPlaceholder(string typeID)
-        {
-            return typeID.Contains("!0");
-        }
-
-        /// <summary> returns whether this type ID is a placeholder, i.e., it begins with "!".</summary>
-        /// <param name="symbol">The symbol to validate.</param>
-        /// <returns>true if the symbol is a placeholder, false if not</returns>
-        public static bool IsPlaceholder(string symbol)
-        {
-            return symbol.StartsWith("!");
-        }
-
-        /// <summary>Determine whether two type IDs look like the same type, accounting for placeholder values such as !0.</summary>
-        /// <param name="a">The type ID to compare.</param>
-        /// <param name="b">The other type ID to compare.</param>
-        /// <returns>true if the type IDs look like the same type, false if not.</returns>
-        public static bool LooksLikeSameType(TypeReference a, TypeReference b)
-        {
-            string typeA = RewriteHelper.GetComparableTypeID(a);
-            string typeB = RewriteHelper.GetComparableTypeID(b);
-
-            string placeholderType = "", actualType = "";
-
-            if (RewriteHelper.HasPlaceholder(typeA))
-            {
-                placeholderType = typeA;
-                actualType = typeB;
-            }
-            else if (RewriteHelper.HasPlaceholder(typeB))
-            {
-                placeholderType = typeB;
-                actualType = typeA;
-            }
-            else
-                return typeA == typeB;
-
-            return RewriteHelper.PlaceholderTypeValidates(placeholderType, actualType);
-        }
-
-        /// <summary>Get a unique string representation of a type.</summary>
-        /// <param name="type">The type reference.</param>
-        private static string GetComparableTypeID(TypeReference type)
-        {
-            return RewriteHelper.StripTypeNamePattern.Replace(type.FullName, "");
-        }
-
-        protected class SymbolLocation
-        {
-            public string symbol;
-            public int depth;
-
-            public SymbolLocation(string symbol, int depth)
-            {
-                this.symbol = symbol;
-                this.depth = depth;
-            }
-        }
-
-        private static List<char> symbolBoundaries = new List<char> { '<', '>', ',' };
-
-        /// <summary> Traverses and parses out symbols from a type which does not contain placeholder values.</summary>
-        /// <param name="type">The type to traverse.</param>
-        /// <param name="typeSymbols">A List in which to store the parsed symbols.</param>
-        private static void TraverseActualType(string type, List<SymbolLocation> typeSymbols)
-        {
-            int depth = 0;
-            string symbol = "";
-
-            foreach (char c in type)
-            {
-                if (RewriteHelper.symbolBoundaries.Contains(c))
-                {
-                    typeSymbols.Add(new SymbolLocation(symbol, depth));
-                    symbol = "";
-                    switch (c)
-                    {
-                        case '<':
-                            depth++;
-                            break;
-                        case '>':
-                            depth--;
-                            break;
-                        default:
-                            break;
-                    }
-                }
-                else
-                    symbol += c;
-            }
-        }
-
-        /// <summary> Determines whether two symbols in a type ID match, accounting for placeholders such as !0.</summary>
-        /// <param name="symbolA">A symbol in a typename which contains placeholders.</param>
-        /// <param name="symbolB">A symbol in a typename which does not contain placeholders.</param>
-        /// <param name="placeholderMap">A dictionary containing a mapping of placeholders to concrete types.</param>
-        /// <returns>true if the symbols match, false if not.</returns>
-        private static bool SymbolsMatch(SymbolLocation symbolA, SymbolLocation symbolB, Dictionary<string, string> placeholderMap)
-        {
-            if (symbolA.depth != symbolB.depth)
-                return false;
-
-            if (!RewriteHelper.IsPlaceholder(symbolA.symbol))
-            {
-                return symbolA.symbol == symbolB.symbol;
-            }
-
-            if (placeholderMap.ContainsKey(symbolA.symbol))
-            {
-                return placeholderMap[symbolA.symbol] == symbolB.symbol;
-            }
-
-            placeholderMap[symbolA.symbol] = symbolB.symbol;
-
-            return true;
-        }
-
-        /// <summary> Determines whether a type which has placeholders correctly resolves to the concrete type provided. </summary>
-        /// <param name="type">A type containing placeholders such as !0.</param>
-        /// <param name="typeSymbols">The list of symbols extracted from the concrete type.</param>
-        /// <returns>true if the type resolves correctly, false if not.</returns>
-        private static bool PlaceholderTypeResolvesToActualType(string type, List<SymbolLocation> typeSymbols)
-        {
-            Dictionary<string, string> placeholderMap = new Dictionary<string, string>();
-
-            int depth = 0, symbolCount = 0;
-            string symbol = "";
-
-            foreach (char c in type)
-            {
-                if (symbolBoundaries.Contains(c))
-                {
-                    bool match = RewriteHelper.SymbolsMatch(new SymbolLocation(symbol, depth), typeSymbols[symbolCount], placeholderMap);
-                    if (typeSymbols.Count <= symbolCount ||
-                        !match)
-                        return false;
-
-                    symbolCount++;
-                    symbol = "";
-                    switch (c)
-                    {
-                        case '<':
-                            depth++;
-                            break;
-                        case '>':
-                            depth--;
-                            break;
-                        default:
-                            break;
-                    }
-                }
-                else
-                    symbol += c;
-            }
-
-            return true;
-        }
-
-        /// <summary>Determines whether a type with placeholders in it matches a type without placeholders.</summary>
-        /// <param name="placeholderType">The type with placeholders in it.</param>
-        /// <param name="actualType">The type without placeholders.</param>
-        /// <returns>true if the placeholder type can resolve to the actual type, false if not.</returns>
-        private static bool PlaceholderTypeValidates(string placeholderType, string actualType)
-        {
-            List<SymbolLocation> typeSymbols = new List<SymbolLocation>();
-
-            RewriteHelper.TraverseActualType(actualType, typeSymbols);
-            return PlaceholderTypeResolvesToActualType(placeholderType, typeSymbols);
         }
     }
 }

--- a/src/SMAPI/Framework/ModLoading/RewriteHelper.cs
+++ b/src/SMAPI/Framework/ModLoading/RewriteHelper.cs
@@ -183,7 +183,6 @@ namespace StardewModdingAPI.Framework.ModLoading
         /// <returns>true if the symbols match, false if not.</returns>
         private static bool SymbolsMatch(SymbolLocation symbolA, SymbolLocation symbolB, Dictionary<string, string> placeholderMap)
         {
-            System.Console.Write($"comparing {symbolA.symbol} at depth {symbolA.depth} to {symbolB.symbol} at {symbolB.depth}");
             if (symbolA.depth != symbolB.depth)
                 return false;
 

--- a/src/SMAPI/Framework/ModLoading/RewriteHelper.cs
+++ b/src/SMAPI/Framework/ModLoading/RewriteHelper.cs
@@ -114,7 +114,7 @@ namespace StardewModdingAPI.Framework.ModLoading
         /// <returns>true if the type IDs look like the same type, false if not.</returns>
         public static bool LooksLikeSameType(string typeA, string typeB)
         {
-            string placeholderType, actualType = "";
+            string placeholderType = "", actualType = "";
 
             if (RewriteHelper.HasPlaceholder(typeA))
             {

--- a/src/SMAPI/Framework/ModLoading/TypeReferenceComparer.cs
+++ b/src/SMAPI/Framework/ModLoading/TypeReferenceComparer.cs
@@ -1,0 +1,209 @@
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Mono.Cecil;
+
+namespace StardewModdingAPI.Framework.ModLoading
+{
+    /// <summary>Performs heuristic equality checks for <see cref="TypeReference"/> instances.</summary>
+    internal class TypeReferenceComparer : IEqualityComparer<TypeReference>
+    {
+        /*********
+        ** Properties
+        *********/
+        /// <summary>A pattern matching type name substrings to strip for display.</summary>
+        private readonly Regex StripTypeNamePattern = new Regex(@"`\d+(?=<)", RegexOptions.Compiled);
+
+        private List<char> symbolBoundaries = new List<char> { '<', '>', ',' };
+
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Get whether the specified objects are equal.</summary>
+        /// <param name="a">The first object to compare.</param>
+        /// <param name="b">The second object to compare.</param>
+        public bool Equals(TypeReference a, TypeReference b)
+        {
+            string typeA = this.GetComparableTypeID(a);
+            string typeB = this.GetComparableTypeID(b);
+
+            string placeholderType = "", actualType = "";
+
+            if (this.HasPlaceholder(typeA))
+            {
+                placeholderType = typeA;
+                actualType = typeB;
+            }
+            else if (this.HasPlaceholder(typeB))
+            {
+                placeholderType = typeB;
+                actualType = typeA;
+            }
+            else
+                return typeA == typeB;
+
+            return this.PlaceholderTypeValidates(placeholderType, actualType);
+        }
+
+        /// <summary>Get a hash code for the specified object.</summary>
+        /// <param name="obj">The object for which a hash code is to be returned.</param>
+        /// <exception cref="T:System.ArgumentNullException">The object type is a reference type and <paramref name="obj" /> is null.</exception>
+        public int GetHashCode(TypeReference obj)
+        {
+            return obj.GetHashCode();
+        }
+
+
+        /*********
+        ** Private methods
+        *********/
+        /// <summary>Get a unique string representation of a type.</summary>
+        /// <param name="type">The type reference.</param>
+        private string GetComparableTypeID(TypeReference type)
+        {
+            return this.StripTypeNamePattern.Replace(type.FullName, "");
+        }
+
+        /// <summary>Determine whether this type ID has a placeholder such as !0.</summary>
+        /// <param name="typeID">The type to check.</param>
+        /// <returns>true if the type ID contains a placeholder, false if not.</returns>
+        private bool HasPlaceholder(string typeID)
+        {
+            return typeID.Contains("!0");
+        }
+
+        /// <summary> returns whether this type ID is a placeholder, i.e., it begins with "!".</summary>
+        /// <param name="symbol">The symbol to validate.</param>
+        /// <returns>true if the symbol is a placeholder, false if not</returns>
+        private bool IsPlaceholder(string symbol)
+        {
+            return symbol.StartsWith("!");
+        }
+
+        /// <summary> Traverses and parses out symbols from a type which does not contain placeholder values.</summary>
+        /// <param name="type">The type to traverse.</param>
+        /// <param name="typeSymbols">A List in which to store the parsed symbols.</param>
+        private void TraverseActualType(string type, List<SymbolLocation> typeSymbols)
+        {
+            int depth = 0;
+            string symbol = "";
+
+            foreach (char c in type)
+            {
+                if (this.symbolBoundaries.Contains(c))
+                {
+                    typeSymbols.Add(new SymbolLocation(symbol, depth));
+                    symbol = "";
+                    switch (c)
+                    {
+                        case '<':
+                            depth++;
+                            break;
+                        case '>':
+                            depth--;
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                else
+                    symbol += c;
+            }
+        }
+
+        /// <summary> Determines whether two symbols in a type ID match, accounting for placeholders such as !0.</summary>
+        /// <param name="symbolA">A symbol in a typename which contains placeholders.</param>
+        /// <param name="symbolB">A symbol in a typename which does not contain placeholders.</param>
+        /// <param name="placeholderMap">A dictionary containing a mapping of placeholders to concrete types.</param>
+        /// <returns>true if the symbols match, false if not.</returns>
+        private bool SymbolsMatch(SymbolLocation symbolA, SymbolLocation symbolB, Dictionary<string, string> placeholderMap)
+        {
+            if (symbolA.depth != symbolB.depth)
+                return false;
+
+            if (!this.IsPlaceholder(symbolA.symbol))
+            {
+                return symbolA.symbol == symbolB.symbol;
+            }
+
+            if (placeholderMap.ContainsKey(symbolA.symbol))
+            {
+                return placeholderMap[symbolA.symbol] == symbolB.symbol;
+            }
+
+            placeholderMap[symbolA.symbol] = symbolB.symbol;
+
+            return true;
+        }
+
+        /// <summary> Determines whether a type which has placeholders correctly resolves to the concrete type provided. </summary>
+        /// <param name="type">A type containing placeholders such as !0.</param>
+        /// <param name="typeSymbols">The list of symbols extracted from the concrete type.</param>
+        /// <returns>true if the type resolves correctly, false if not.</returns>
+        private bool PlaceholderTypeResolvesToActualType(string type, List<SymbolLocation> typeSymbols)
+        {
+            Dictionary<string, string> placeholderMap = new Dictionary<string, string>();
+
+            int depth = 0, symbolCount = 0;
+            string symbol = "";
+
+            foreach (char c in type)
+            {
+                if (this.symbolBoundaries.Contains(c))
+                {
+                    bool match = this.SymbolsMatch(new SymbolLocation(symbol, depth), typeSymbols[symbolCount], placeholderMap);
+                    if (typeSymbols.Count <= symbolCount ||
+                        !match)
+                        return false;
+
+                    symbolCount++;
+                    symbol = "";
+                    switch (c)
+                    {
+                        case '<':
+                            depth++;
+                            break;
+                        case '>':
+                            depth--;
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                else
+                    symbol += c;
+            }
+
+            return true;
+        }
+
+        /// <summary>Determines whether a type with placeholders in it matches a type without placeholders.</summary>
+        /// <param name="placeholderType">The type with placeholders in it.</param>
+        /// <param name="actualType">The type without placeholders.</param>
+        /// <returns>true if the placeholder type can resolve to the actual type, false if not.</returns>
+        private bool PlaceholderTypeValidates(string placeholderType, string actualType)
+        {
+            List<SymbolLocation> typeSymbols = new List<SymbolLocation>();
+
+            this.TraverseActualType(actualType, typeSymbols);
+            return PlaceholderTypeResolvesToActualType(placeholderType, typeSymbols);
+        }
+
+
+
+        /*********
+        ** Inner classes
+        *********/
+        protected class SymbolLocation
+        {
+            public string symbol;
+            public int depth;
+
+            public SymbolLocation(string symbol, int depth)
+            {
+                this.symbol = symbol;
+                this.depth = depth;
+            }
+        }
+    }
+}

--- a/src/SMAPI/Metadata/InstructionMetadata.cs
+++ b/src/SMAPI/Metadata/InstructionMetadata.cs
@@ -17,7 +17,7 @@ namespace StardewModdingAPI.Metadata
         *********/
         /// <summary>The assembly names to which to heuristically detect broken references.</summary>
         /// <remarks>The current implementation only works correctly with assemblies that should always be present.</remarks>
-        private readonly string[] ValidateReferencesToAssemblies = { "StardewModdingAPI", "Stardew Valley", "StardewValley" };
+        private readonly string[] ValidateReferencesToAssemblies = { "StardewModdingAPI", "Stardew Valley", "StardewValley", "Netcode" };
 
 
         /*********

--- a/src/SMAPI/StardewModdingAPI.csproj
+++ b/src/SMAPI/StardewModdingAPI.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Framework\ContentManagers\IContentManager.cs" />
     <Compile Include="Framework\ContentManagers\ModContentManager.cs" />
     <Compile Include="Framework\Models\ModFolderExport.cs" />
+    <Compile Include="Framework\ModLoading\TypeReferenceComparer.cs" />
     <Compile Include="Framework\Patching\GamePatcher.cs" />
     <Compile Include="Framework\Patching\IHarmonyPatch.cs" />
     <Compile Include="Framework\Serialisation\ColorConverter.cs" />


### PR DESCRIPTION
Expands the UnexpectedTypeFinder heuristic to resolve placeholders like `!0` when they are found in one of the types being compared.