### PR TITLE
Log Parser - Display author of content packs

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -21,6 +21,7 @@
 
 * For the web UI:
   * The log parser now has a separate filter for game messages.
+  * The log parser now displays the author of each content pack.
 
 * For modders:
   * Added [data API](https://stardewvalleywiki.com/Modding:Modder_Guide/APIs/Data).

--- a/src/SMAPI.Web/Views/LogParser/Index.cshtml
+++ b/src/SMAPI.Web/Views/LogParser/Index.cshtml
@@ -165,7 +165,18 @@ else if (Model.ParsedLog?.IsValid == true)
                             </div>
                         }
                     </td>
-                    <td v-pre>@mod.Author</td>
+                    <td v-pre>
+                        @mod.Author
+                        @if (contentPacks != null && contentPacks.TryGetValue(mod.Name, out contentPackList))
+                        {
+                            <div class="content-packs">
+                                @foreach (var contentPack in contentPackList)
+                                {
+                                    <text>+ @contentPack.Author</text><br />
+                                }
+                            </div>
+                        }
+                    </td>
                     @if (mod.Errors == 0)
                     {
                         <td v-pre class="color-green">no errors</td>


### PR DESCRIPTION
This PR displays the author of each content pack in the log parser. It also updates the release notes.
Here's an example of what it looks like:
![content_pack_author_names](https://user-images.githubusercontent.com/21993469/46641069-28063200-cb35-11e8-9b40-3a358dad8a1c.PNG)
