### PR TITLE
Make Log Parser Checkboxes + Show/Hide All Buttons Invisible Instead Of Hidden

### DIFF
--- a/src/SMAPI.Web/Views/LogParser/Index.cshtml
+++ b/src/SMAPI.Web/Views/LogParser/Index.cshtml
@@ -145,14 +145,14 @@ else if (Model.ParsedLog?.IsValid == true)
                 @if (!Model.ShowRaw)
                 {
                     <span class="notice txt"><i>click any mod to filter</i></span>
-                    <span class="notice btn txt" v-on:click="showAllMods" v-show="stats.modsHidden > 0">show all</span>
-                    <span class="notice btn txt" v-on:click="hideAllMods" v-show="stats.modsShown > 0 && stats.modsHidden > 0">hide all</span>
+                    <span class="notice btn txt" v-on:click="showAllMods" v-bind:class="{ invisible: !anyModsHidden }">show all</span>
+                    <span class="notice btn txt" v-on:click="hideAllMods" v-bind:class="{ invisible: !anyModsShown || !anyModsHidden }">hide all</span>
                 }
             </caption>
             @foreach (var mod in Model.ParsedLog.Mods.Where(p => p.ContentPackFor == null))
             {
                 <tr v-on:click="toggleMod('@Model.GetSlug(mod.Name)')" class="mod-entry" v-bind:class="{ hidden: !showMods['@Model.GetSlug(mod.Name)'] }">
-                    <td><input type="checkbox" v-bind:checked="showMods['@Model.GetSlug(mod.Name)']" v-show="anyModsHidden" /></td>
+                    <td><input type="checkbox" v-bind:checked="showMods['@Model.GetSlug(mod.Name)']" v-bind:class="{ invisible: !anyModsHidden }" /></td>
                     <td v-pre>
                         <strong>@mod.Name</strong> @mod.Version
                         @if (contentPacks != null && contentPacks.TryGetValue(mod.Name, out LogModInfo[] contentPackList))

--- a/src/SMAPI.Web/wwwroot/Content/css/log-parser.css
+++ b/src/SMAPI.Web/wwwroot/Content/css/log-parser.css
@@ -63,6 +63,10 @@ table#metadata, table#mods {
     box-shadow: 1px 1px 1px 1px #dddddd;
 }
 
+.invisible {
+    visibility: hidden;
+}
+
 #mods {
     min-width: 400px;
 }


### PR DESCRIPTION
This makes the check boxes and show/hide all buttons in the log parser change how they're displayed using visibility instead of showing/hiding. This way, the elements take up space regardless so the filter list doesn't jump around when you toggle them.

Here are examples of what the change looks like:
https://i.imgur.com/qKzMPSv.gif

https://i.imgur.com/DGu0MLB.gif

Let me know if there should be any changes :)