### PR TITLE
Stop log messages from jumping around in hover edge case

### DIFF
--- a/src/SMAPI.Web/Views/LogParser/Index.cshtml
+++ b/src/SMAPI.Web/Views/LogParser/Index.cshtml
@@ -17,7 +17,7 @@
     {
         <meta name="robots" content="noindex" />
     }
-    <link rel="stylesheet" href="~/Content/css/log-parser.css?r=20190310" />
+    <link rel="stylesheet" href="~/Content/css/log-parser.css?r=20190314" />
     <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.3.1/dist/jquery.min.js" crossorigin="anonymous"></script>
     <script src="~/Content/js/log-parser.js?r=20190310"></script>

--- a/src/SMAPI.Web/wwwroot/Content/css/log-parser.css
+++ b/src/SMAPI.Web/wwwroot/Content/css/log-parser.css
@@ -255,7 +255,6 @@ table caption {
 }
 
 #log td[data-title]:hover {
-    font-size: 1px;
     overflow: inherit;
     position: relative;
 }


### PR DESCRIPTION
This PR removes a CSS rule that can cause this to occur:
![demo](https://user-images.githubusercontent.com/21993469/54335363-bd32b880-45f6-11e9-8e72-2eaac678629d.gif)

I also updated the revision number for the css file link.
