### PR TITLE
Fix saving event doc typo

### DIFF
--- a/src/SMAPI/Events/IGameLoopEvents.cs
+++ b/src/SMAPI/Events/IGameLoopEvents.cs
@@ -26,7 +26,7 @@ namespace StardewModdingAPI.Events
         /// <summary>Raised after the game finishes creating the save file.</summary>
         event EventHandler<SaveCreatedEventArgs> SaveCreated;
 
-        /// <summary>Raised before the game begins writes data to the save file (except the initial save creation).</summary>
+        /// <summary>Raised before the game begins writing data to the save file (except the initial save creation).</summary>
         event EventHandler<SavingEventArgs> Saving;
 
         /// <summary>Raised after the game finishes writing data to the save file (except the initial save creation).</summary>


### PR DESCRIPTION
This PR fixes a typo in the Saving event XML docs, `begins writes data` -> `begins writing data`.