### PR TITLE
Prevent linux install failing with cryptic error

### DIFF
--- a/src/SMAPI.Installer/unix-install.sh
+++ b/src/SMAPI.Installer/unix-install.sh
@@ -12,6 +12,9 @@ elif type type >/dev/null 2>&1; then
     COMMAND="type"
 fi
 
+# if $TERM is not set to xterm, mono will bail out when attempting to write to the console.
+export TERM=xterm
+
 # validate Mono & run installer
 if $COMMAND mono >/dev/null 2>&1; then
     mono internal/unix-install.exe


### PR DESCRIPTION
This avoids the error described at https://stackoverflow.com/questions/49242075/mono-bug-magic-number-is-wrong-542

When trying to install on linux, if you have `TERM=xterm-256color` (the default, in my case), the installer will fail to run with a cryptic error:
```
System.TypeInitializationException: The type initializer for 'System.Console' threw an exception. ---> System.TypeInitializationException: The type initializer for 'System.ConsoleDriver' threw an exception. ---> System.Exception: Magic number is wrong: 542
```