### PR TITLE
[JSON Validator] Change 'log' to 'JSON file' on the JSON validator page

### DIFF
--- a/src/SMAPI.Web/Views/JsonValidator/Index.cshtml
+++ b/src/SMAPI.Web/Views/JsonValidator/Index.cshtml
@@ -75,7 +75,7 @@ else if (!isEditView && Model.PasteID != null)
     <div class="save-metadata" v-pre>
         @if (Model.Expiry != null)
         {
-            <text>This log will expire in @((DateTime.UtcNow - Model.Expiry.Value).Humanize()). </text>
+            <text>This JSON file will expire in @((DateTime.UtcNow - Model.Expiry.Value).Humanize()). </text>
         }
         <!--@Model.UploadWarning-->
     </div>


### PR DESCRIPTION
This PR fixes a typo where the JSON validator page displays `this log file will expire...`, but the file isn't a log.