### PR TITLE
[Log Parser] Fix parsing errors on content packs without authors

### DIFF
--- a/src/SMAPI.Web/Framework/LogParsing/LogParser.cs
+++ b/src/SMAPI.Web/Framework/LogParsing/LogParser.cs
@@ -37,7 +37,7 @@ namespace StardewModdingAPI.Web.Framework.LogParsing
         private readonly Regex ContentPackListStartPattern = new Regex(@"^Loaded \d+ content packs:$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         /// <summary>A regex pattern matching an entry in SMAPI's content pack list.</summary>
-        private readonly Regex ContentPackListEntryPattern = new Regex(@"^   (?<name>.+) (?<version>.+) by (?<author>.+) \| for (?<for>.+?)(?: \| (?<description>.+))?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private readonly Regex ContentPackListEntryPattern = new Regex(@"^   (?<name>.+?) (?<version>" + SemanticVersion.UnboundedVersionPattern + @")(?: by (?<author>[^\|]+))? \| for (?<for>[^\|]+)(?: \| (?<description>.+))?$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         /// <summary>A regex pattern matching the start of SMAPI's mod update list.</summary>
         private readonly Regex ModUpdateListStartPattern = new Regex(@"^You can update \d+ mods?:$", RegexOptions.Compiled | RegexOptions.IgnoreCase);

--- a/src/SMAPI/Framework/SCore.cs
+++ b/src/SMAPI/Framework/SCore.cs
@@ -783,7 +783,7 @@ namespace StardewModdingAPI.Framework
                     this.Monitor.Log(
                         $"   {metadata.DisplayName} {manifest.Version}"
                         + (!string.IsNullOrWhiteSpace(manifest.Author) ? $" by {manifest.Author}" : "")
-                        + (metadata.IsContentPack ? $" | for {GetModDisplayName(metadata.Manifest.ContentPackFor.UniqueID)}" : "")
+                        + $" | for {GetModDisplayName(metadata.Manifest.ContentPackFor.UniqueID)}"
                         + (!string.IsNullOrWhiteSpace(manifest.Description) ? $" | {manifest.Description}" : ""),
                         LogLevel.Info
                     );


### PR DESCRIPTION
## The problem
This PR fixes the content pack list entry pattern not properly handling the case where there is no author for a mod. In that case the ` | by ...` isn't output, so the pattern fails to match the entries.

An example log where a content pack has no author is here: https://smapi.io/log/8e0af32e9a10435e9d51dfd5efef16a1. It correctly parses now.

## The solution
I updated the content pack list entry pattern to match the mod list entry pattern (which handles optional authors properly) and then modified it to include the required ` | for ...` section.

## Also
I noticed that when SMAPI logs content packs it does a check on whether the mod is a content pack. This is always true because it's going through a list of content packs, so that's not needed. I removed the ternary expression.