### PR TITLE
[SMAPI] Fix update marker file not being created

### DIFF
--- a/src/SMAPI/Framework/SCore.cs
+++ b/src/SMAPI/Framework/SCore.cs
@@ -590,6 +590,8 @@ namespace StardewModdingAPI.Framework
                     else
                         this.Monitor.Log("   SMAPI okay.", LogLevel.Trace);
 
+                    updateFound = response.SuggestedUpdate?.Version;
+
                     // show errors
                     if (response.Errors.Any())
                     {


### PR DESCRIPTION
The `updateFound` variable is used to create an update marker file. Currently, nothing sets the value of it so the update marker file is never created.

This PR fixes that bug by setting it based on the new suggested update response.

(Mod Update Menu depends on the update marker file existing to get info on whether there is a SMAPI update or not.)