### PR TITLE
SDate: Add WorldDate conversions and features

### DIFF
--- a/src/SMAPI.Tests/Utilities/SDateTests.cs
+++ b/src/SMAPI.Tests/Utilities/SDateTests.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using NUnit.Framework;
 using StardewModdingAPI.Utilities;
+using StardewValley;
+using LC = StardewValley.LocalizedContentManager.LanguageCode;
 
 namespace SMAPI.Tests.Utilities
 {
@@ -82,6 +84,21 @@ namespace SMAPI.Tests.Utilities
         }
 
         /****
+        ** SeasonIndex
+        ****/
+        [Test(Description = "Assert the numeric index of the season.")]
+        [TestCase("01 spring Y1", ExpectedResult = 0)]
+        [TestCase("02 summer Y1", ExpectedResult = 1)]
+        [TestCase("28 fall Y1", ExpectedResult = 2)]
+        [TestCase("01 winter Y1", ExpectedResult = 3)]
+        [TestCase("01 winter Y2", ExpectedResult = 3)]
+        public int SeasonIndex(string dateStr)
+        {
+            // act
+            return this.GetDate(dateStr).SeasonIndex;
+        }
+
+        /****
         ** DayOfWeek
         ****/
         [Test(Description = "Assert the day of week.")]
@@ -148,6 +165,58 @@ namespace SMAPI.Tests.Utilities
         }
 
         /****
+        ** ToLocaleString
+        ****/
+        // TODO: Provide an appropriate XNA/MonoGame context to run this in, or else remove the test.
+        // [Test(Description = "Assert that ToLocaleString returns the expected string in various locales.")]
+        // [TestCase("14 spring Y1", LC.en, ExpectedResult = "Day 14 of Spring, Year 1")]
+        // [TestCase("01 summer Y16", LC.en, ExpectedResult = "Day 1 of Summer, Year 16")]
+        // [TestCase("28 fall Y10", LC.en, ExpectedResult = "Day 28 of Fall, Year 10")]
+        // [TestCase("01 winter Y1", LC.en, ExpectedResult = "Day 1 of Winter, Year 1")]
+        // [TestCase("14 spring Y1", LC.es, ExpectedResult = "Día 14 de primavera, año 1")]
+        // [TestCase("01 summer Y16", LC.es, ExpectedResult = "Día 1 de verano, año 16")]
+        // [TestCase("28 fall Y10", LC.es, ExpectedResult = "Día 28 de otoño, año 10")]
+        // [TestCase("01 winter Y1", LC.es, ExpectedResult = "Día 1 de invierno, año 1")]
+        // public string ToLocaleString(string dateStr, LC langCode)
+        // {
+        //     LC oldCode = LocalizedContentManager.CurrentLanguageCode;
+        //     try
+        //     {
+        //         LocalizedContentManager.CurrentLanguageCode = langCode;
+        //         return this.GetDate(dateStr).ToLocaleString();
+        //     }
+        //     finally
+        //     {
+        //         LocalizedContentManager.CurrentLanguageCode = oldCode;
+        //     }
+        // }
+
+        /****
+        ** FromDaysSinceStart
+        ****/
+        [Test(Description = "Assert that FromDaysSinceStart returns the expected date.")]
+        [TestCase(1, ExpectedResult = "01 spring Y1")]
+        [TestCase(2, ExpectedResult = "02 spring Y1")]
+        [TestCase(28, ExpectedResult = "28 spring Y1")]
+        [TestCase(29, ExpectedResult = "01 summer Y1")]
+        [TestCase(141, ExpectedResult = "01 summer Y2")]
+        public string FromDaysSinceStart(int daysSinceStart)
+        {
+            // act
+            return SDate.FromDaysSinceStart(daysSinceStart).ToString();
+        }
+
+        [Test(Description = "Assert that FromDaysSinceStart throws an exception if the number of days is invalid.")]
+        [TestCase(-1)] // day < 0
+        [TestCase(0)] // day == 0
+        [SuppressMessage("ReSharper", "AssignmentIsFullyDiscarded", Justification = "Deliberate for unit test.")]
+        public void FromDaysSinceStart_RejectsInvalidValues(int daysSinceStart)
+        {
+            // act & assert
+            Assert.Throws<ArgumentException>(() => _ = SDate.FromDaysSinceStart(daysSinceStart), "Passing the invalid number of days didn't throw the expected exception.");
+        }
+
+        /****
         ** AddDays
         ****/
         [Test(Description = "Assert that AddDays returns the expected date.")]
@@ -164,6 +233,17 @@ namespace SMAPI.Tests.Utilities
         public string AddDays(string dateStr, int addDays)
         {
             return this.GetDate(dateStr).AddDays(addDays).ToString();
+        }
+
+        [Test(Description = "Assert that AddDays throws an exception if the number of days is invalid.")]
+        [TestCase("01 spring Y1", -1)]
+        [TestCase("01 summer Y1", -29)]
+        [TestCase("01 spring Y2", -113)]
+        [SuppressMessage("ReSharper", "AssignmentIsFullyDiscarded", Justification = "Deliberate for unit test.")]
+        public void AddDays_RejectsInvalidValues(string dateStr, int addDays)
+        {
+            // act & assert
+            Assert.Throws<ArithmeticException>(() => _ = this.GetDate(dateStr).AddDays(addDays), "Passing the invalid number of days didn't throw the expected exception.");
         }
 
         /****
@@ -192,6 +272,28 @@ namespace SMAPI.Tests.Utilities
                     }
                 }
             }
+        }
+
+        [Test(Description = "Assert that the SDate operator for WorldDates returns the corresponding SDate.")]
+        [TestCase(0, ExpectedResult = "01 spring Y1")]
+        [TestCase(1, ExpectedResult = "02 spring Y1")]
+        [TestCase(27, ExpectedResult = "28 spring Y1")]
+        [TestCase(28, ExpectedResult = "01 summer Y1")]
+        [TestCase(140, ExpectedResult = "01 summer Y2")]
+        public string Operators_SDate_WorldDate(int totalDays)
+        {
+            return ((SDate)new WorldDate { TotalDays = totalDays }).ToString();
+        }
+
+        [Test(Description = "Assert that the WorldDate operator returns the corresponding WorldDate.")]
+        [TestCase("01 spring Y1", ExpectedResult = 0)]
+        [TestCase("02 spring Y1", ExpectedResult = 1)]
+        [TestCase("28 spring Y1", ExpectedResult = 27)]
+        [TestCase("01 summer Y1", ExpectedResult = 28)]
+        [TestCase("01 summer Y2", ExpectedResult = 140)]
+        public int Operators_WorldDate(string dateStr)
+        {
+            return ((WorldDate)this.GetDate(dateStr)).TotalDays;
         }
 
         [Test(Description = "Assert that the == operator returns the expected values. We only need a few test cases, since it's based on GetHashCode which is tested more thoroughly.")]

--- a/src/SMAPI/Utilities/SDate.cs
+++ b/src/SMAPI/Utilities/SDate.cs
@@ -29,6 +29,9 @@ namespace StardewModdingAPI.Utilities
         /// <summary>The season name.</summary>
         public string Season { get; }
 
+        /// <summary>The season index.</summary>
+        public int SeasonIndex { get; }
+
         /// <summary>The year.</summary>
         public int Year { get; }
 
@@ -61,6 +64,20 @@ namespace StardewModdingAPI.Utilities
         public static SDate Now()
         {
             return new SDate(Game1.dayOfMonth, Game1.currentSeason, Game1.year, allowDayZero: true);
+        }
+
+        /// <summary>Get the date equivalent to the given WorldDate.</summary>
+        /// <param name="worldDate">A date returned from a core game property or method.</param>
+        public static SDate FromWorldDate(WorldDate worldDate)
+        {
+            return new SDate(worldDate.DayOfMonth, worldDate.Season, worldDate.Year, allowDayZero: true);
+        }
+
+        /// <summary>Get the date falling the given number of days after 0 spring Y1.</summary>
+        /// <param name="daysSinceStart">The number of days since 0 spring Y1.</param>
+        public static SDate FromDaysSinceStart(int daysSinceStart)
+        {
+            return new SDate(0, "spring", 1, allowDayZero: true).AddDays(daysSinceStart);
         }
 
         /// <summary>Get a new date with the given number of days added.</summary>
@@ -96,6 +113,18 @@ namespace StardewModdingAPI.Utilities
         public override string ToString()
         {
             return $"{this.Day:00} {this.Season} Y{this.Year}";
+        }
+
+        /// <summary>Get a string representation of the date in the current game locale.</summary>
+        public string ToLocaleString()
+        {
+            return this.ToWorldDate().Localize();
+        }
+
+        /// <summary>Get the date as an instance of the game's WorldDate class. This is intended for passing to core game methods.</summary>
+        public WorldDate ToWorldDate()
+        {
+            return new WorldDate(this.Year, this.Season, this.Day);
         }
 
         /****
@@ -200,6 +229,7 @@ namespace StardewModdingAPI.Utilities
             // initialize
             this.Day = day;
             this.Season = season;
+            this.SeasonIndex = this.GetSeasonIndex(season);
             this.Year = year;
             this.DayOfWeek = this.GetDayOfWeek(day);
             this.DaysSinceStart = this.GetDaysSinceStart(day, season, year);

--- a/src/SMAPI/Utilities/SDate.cs
+++ b/src/SMAPI/Utilities/SDate.cs
@@ -66,18 +66,18 @@ namespace StardewModdingAPI.Utilities
             return new SDate(Game1.dayOfMonth, Game1.currentSeason, Game1.year, allowDayZero: true);
         }
 
-        /// <summary>Get the date equivalent to the given WorldDate.</summary>
-        /// <param name="worldDate">A date returned from a core game property or method.</param>
-        public static SDate FromWorldDate(WorldDate worldDate)
-        {
-            return new SDate(worldDate.DayOfMonth, worldDate.Season, worldDate.Year, allowDayZero: true);
-        }
-
         /// <summary>Get the date falling the given number of days after 0 spring Y1.</summary>
         /// <param name="daysSinceStart">The number of days since 0 spring Y1.</param>
         public static SDate FromDaysSinceStart(int daysSinceStart)
         {
-            return new SDate(0, "spring", 1, allowDayZero: true).AddDays(daysSinceStart);
+            try
+            {
+                return new SDate(0, "spring", 1, allowDayZero: true).AddDays(daysSinceStart);
+            }
+            catch (ArithmeticException)
+            {
+                throw new ArgumentException($"Invalid daysSinceStart '{daysSinceStart}', must be at least 1.");
+            }
         }
 
         /// <summary>Get a new date with the given number of days added.</summary>
@@ -118,13 +118,7 @@ namespace StardewModdingAPI.Utilities
         /// <summary>Get a string representation of the date in the current game locale.</summary>
         public string ToLocaleString()
         {
-            return this.ToWorldDate().Localize();
-        }
-
-        /// <summary>Get the date as an instance of the game's WorldDate class. This is intended for passing to core game methods.</summary>
-        public WorldDate ToWorldDate()
-        {
-            return new WorldDate(this.Year, this.Season, this.Day);
+            return Utility.getDateStringFor(this.Day, this.SeasonIndex, this.Year);
         }
 
         /****
@@ -153,6 +147,19 @@ namespace StardewModdingAPI.Utilities
         /****
         ** Operators
         ****/
+        /// <summary>Get the SDate equivalent to the given WorldDate.</summary>
+        /// <param name="worldDate">A date returned from a core game property or method.</param>
+        public static explicit operator SDate(WorldDate worldDate)
+        {
+            return new SDate(worldDate.DayOfMonth, worldDate.Season, worldDate.Year, allowDayZero: true);
+        }
+
+        /// <summary>Get the SDate as an instance of the game's WorldDate class. This is intended for passing to core game methods.</summary>
+        public static explicit operator WorldDate(SDate date)
+        {
+            return new WorldDate(date.Year, date.Season, date.Day);
+        }
+
         /// <summary>Get whether one date is equal to another.</summary>
         /// <param name="date">The base date to compare.</param>
         /// <param name="other">The other date to compare.</param>


### PR DESCRIPTION
After my last PR I looked into what it would take to replace `WorldDate` with `SDate` in PATV and Scrying Orb. This PR fills in features from `WorldDate` and allows interconversion to support use of core game code that expects `WorldDate`.

- `SeasonIndex`: just exposing existing calculation
- `FromWorldDate()` and `ToWorldDate()`: conversion
- `FromDaysSinceStart()`: counterpart to `DaysSinceStart`
- `ToLocaleString()`: Not sure if this is the best name. I know the .NET way is to pass a culture to a `ToString()` overload, but the method in `WorldDate` can only use the current locale.
