### PR TITLE
Bug fix: make it possible for multi patch

### DIFF
--- a/src/SMAPI/Framework/ModLoading/AssemblyLoader.cs
+++ b/src/SMAPI/Framework/ModLoading/AssemblyLoader.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using Mono.Cecil;
+using Mono.Cecil.Cil;
 using StardewModdingAPI.Framework.Exceptions;
 using StardewModdingAPI.Framework.ModLoading.Framework;
 using StardewModdingAPI.Metadata;
@@ -304,7 +305,7 @@ namespace StardewModdingAPI.Framework.ModLoading
                         rewritten |= handler.Handle(module, type, replaceWith);
                     return rewritten;
                 },
-                rewriteInstruction: (instruction, cil, replaceWith) =>
+                rewriteInstruction: (ref Instruction instruction, ILProcessor cil, Action<Instruction> replaceWith) =>
                 {
                     bool rewritten = false;
                     foreach (IInstructionHandler handler in handlers)

--- a/src/SMAPI/Framework/ModLoading/Framework/RecursiveRewriter.cs
+++ b/src/SMAPI/Framework/ModLoading/Framework/RecursiveRewriter.cs
@@ -23,7 +23,7 @@ namespace StardewModdingAPI.Framework.ModLoading.Framework
         /// <param name="cil">The CIL instruction processor.</param>
         /// <param name="replaceWith">Replaces the CIL instruction with the given instruction.</param>
         /// <returns>Returns whether the instruction was changed.</returns>
-        public delegate bool RewriteInstructionDelegate(Instruction instruction, ILProcessor cil, Action<Instruction> replaceWith);
+        public delegate bool RewriteInstructionDelegate(ref Instruction instruction, ILProcessor cil, Action<Instruction> replaceWith);
 
 
         /*********
@@ -144,7 +144,7 @@ namespace StardewModdingAPI.Framework.ModLoading.Framework
 
             // instruction itself
             // (should be done after the above type rewrites to ensure valid types)
-            rewritten |= this.RewriteInstructionImpl(instruction, cil, newInstruction =>
+            rewritten |= this.RewriteInstructionImpl(ref instruction, cil, newInstruction =>
             {
                 rewritten = true;
                 cil.Replace(instruction, newInstruction);


### PR DESCRIPTION
When one patch replace an instruction, another patch didn't aware it due to the variable capture