### PR TITLE
Bug fix: Provide seed to Aggregate op

### DIFF
--- a/src/SMAPI/Framework/ModLoading/Framework/RecursiveRewriter.cs
+++ b/src/SMAPI/Framework/ModLoading/Framework/RecursiveRewriter.cs
@@ -127,7 +127,7 @@ namespace StardewModdingAPI.Framework.ModLoading.Framework
                         return Tuple.Create(anyRewritten, e);
                     }
                 })
-                .Aggregate((a, b) => Tuple.Create(a.Item1 || b.Item1, a.Item2 ?? b.Item2));
+                .Aggregate(Tuple.Create(false, null as Exception), (a, b) => Tuple.Create(a.Item1 || b.Item1, a.Item2 ?? b.Item2));
 
             bool rewritten = result.Item1;
             Exception exception = result.Item2;


### PR DESCRIPTION
For Sequence contains no elements exception, all type was filtered by .Where(type => type.BaseType != null) op