### PR TITLE
Implement event priority attribute

### DIFF
--- a/src/SMAPI/Events/EventPriority.cs
+++ b/src/SMAPI/Events/EventPriority.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace StardewModdingAPI.Events
+{
+    /// <summary>
+    /// Event priority for method handlers.
+    /// </summary>
+    public enum EventPriority
+    {
+        /// <summary>
+        /// Low priority.
+        /// </summary>
+        Low = 3,
+
+        /// <summary>
+        /// Normal priority. This is the default.
+        /// </summary>
+        Normal = 2,
+
+        /// <summary>
+        /// High priority.
+        /// </summary>
+        High = 1,
+    }
+}

--- a/src/SMAPI/Events/EventPriority.cs
+++ b/src/SMAPI/Events/EventPriority.cs
@@ -4,12 +4,12 @@ namespace StardewModdingAPI.Events
     public enum EventPriority
     {
         /// <summary>Low priority.</summary>
-        Low = 3,
+        Low = -1000,
 
         /// <summary>The default priority.</summary>
-        Normal = 2,
+        Normal = 0,
 
         /// <summary>High priority.</summary>
-        High = 1
+        High = 1000
     }
 }

--- a/src/SMAPI/Events/EventPriority.cs
+++ b/src/SMAPI/Events/EventPriority.cs
@@ -1,29 +1,15 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace StardewModdingAPI.Events
 {
-    /// <summary>
-    /// Event priority for method handlers.
-    /// </summary>
+    /// <summary>The event priorities for method handlers.</summary>
     public enum EventPriority
     {
-        /// <summary>
-        /// Low priority.
-        /// </summary>
+        /// <summary>Low priority.</summary>
         Low = 3,
 
-        /// <summary>
-        /// Normal priority. This is the default.
-        /// </summary>
+        /// <summary>The default priority.</summary>
         Normal = 2,
 
-        /// <summary>
-        /// High priority.
-        /// </summary>
-        High = 1,
+        /// <summary>High priority.</summary>
+        High = 1
     }
 }

--- a/src/SMAPI/Events/EventPriorityAttribute.cs
+++ b/src/SMAPI/Events/EventPriorityAttribute.cs
@@ -1,27 +1,24 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace StardewModdingAPI.Events
 {
-    /// <summary>
-    /// An attribute for controlling event priority of an event handler.
-    /// </summary>
+    /// <summary>An attribute which specifies the priority for an event handler.</summary>
     [AttributeUsage(AttributeTargets.Method)]
-    public class EventPriorityAttribute : System.Attribute
+    public class EventPriorityAttribute : Attribute
     {
-        /// <summary>
-        /// The priority for the method marked by this attribute.
-        /// </summary>
-        public EventPriority Priority { get; }
+        /*********
+        ** Accessors
+        *********/
+        /// <summary>The event handler priority, relative to other handlers across all mods registered for this event.</summary>
+        internal EventPriority Priority { get; }
 
-        /// <summary>
-        /// Constructor.
-        /// </summary>
-        /// <param name="priority">The priority for method marked by this attribute.</param>
-        public EventPriorityAttribute( EventPriority priority )
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Construct an instance.</summary>
+        /// <param name="priority">The event handler priority, relative to other handlers across all mods registered for this event. Higher-priority handlers are notified before lower-priority handlers.</param>
+        public EventPriorityAttribute(EventPriority priority)
         {
             this.Priority = priority;
         }

--- a/src/SMAPI/Events/EventPriorityAttribute.cs
+++ b/src/SMAPI/Events/EventPriorityAttribute.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace StardewModdingAPI.Events
+{
+    /// <summary>
+    /// An attribute for controlling event priority of an event handler.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class EventPriorityAttribute : System.Attribute
+    {
+        /// <summary>
+        /// The priority for the method marked by this attribute.
+        /// </summary>
+        public EventPriority Priority { get; }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="priority">The priority for method marked by this attribute.</param>
+        public EventPriorityAttribute( EventPriority priority )
+        {
+            this.Priority = priority;
+        }
+    }
+}

--- a/src/SMAPI/Framework/Events/EventManager.cs
+++ b/src/SMAPI/Framework/Events/EventManager.cs
@@ -174,15 +174,14 @@ namespace StardewModdingAPI.Framework.Events
         ** Public methods
         *********/
         /// <summary>Construct an instance.</summary>
-        /// <param name="monitor">Writes messages to the log.</param>
         /// <param name="modRegistry">The mod registry with which to identify mods.</param>
         /// <param name="performanceMonitor">Tracks performance metrics.</param>
-        public EventManager(IMonitor monitor, ModRegistry modRegistry, PerformanceMonitor performanceMonitor)
+        public EventManager(ModRegistry modRegistry, PerformanceMonitor performanceMonitor)
         {
             // create shortcut initializers
             ManagedEvent<TEventArgs> ManageEventOf<TEventArgs>(string typeName, string eventName, bool isPerformanceCritical = false)
             {
-                return new ManagedEvent<TEventArgs>($"{typeName}.{eventName}", monitor, modRegistry, performanceMonitor, isPerformanceCritical);
+                return new ManagedEvent<TEventArgs>($"{typeName}.{eventName}", modRegistry, performanceMonitor, isPerformanceCritical);
             }
 
             // init events (new)

--- a/src/SMAPI/Framework/Events/ManagedEventHandler.cs
+++ b/src/SMAPI/Framework/Events/ManagedEventHandler.cs
@@ -1,0 +1,62 @@
+using System;
+using StardewModdingAPI.Events;
+
+namespace StardewModdingAPI.Framework.Events
+{
+    /// <summary>An event handler wrapper which tracks metadata about an event handler.</summary>
+    /// <typeparam name="TEventArgs">The event arguments type.</typeparam>
+    internal class ManagedEventHandler<TEventArgs> : IComparable
+    {
+        /*********
+        ** Accessors
+        *********/
+        /// <summary>The event handler method.</summary>
+        public EventHandler<TEventArgs> Handler { get; }
+
+        /// <summary>The order in which the event handler was registered, relative to other handlers for this event.</summary>
+        public int RegistrationOrder { get; }
+
+        /// <summary>The event handler priority, relative to other handlers for this event.</summary>
+        public EventPriority Priority { get; }
+
+        /// <summary>The mod which registered the handler.</summary>
+        public IModMetadata SourceMod { get; set; }
+
+
+        /*********
+        ** Accessors
+        *********/
+        /// <summary>Construct an instance.</summary>
+        /// <param name="handler">The event handler method.</param>
+        /// <param name="registrationOrder">The order in which the event handler was registered, relative to other handlers for this event.</param>
+        /// <param name="priority">The event handler priority, relative to other handlers for this event.</param>
+        /// <param name="sourceMod">The mod which registered the handler.</param>
+        public ManagedEventHandler(EventHandler<TEventArgs> handler, int registrationOrder, EventPriority priority, IModMetadata sourceMod)
+        {
+            this.Handler = handler;
+            this.RegistrationOrder = registrationOrder;
+            this.Priority = priority;
+            this.SourceMod = sourceMod;
+        }
+
+        /// <summary>Get whether the event handler has a custom priority value.</summary>
+        public bool HasCustomPriority()
+        {
+            return this.Priority != EventPriority.Normal;
+        }
+
+        /// <summary>Compares the current instance with another object of the same type and returns an integer that indicates whether the current instance precedes, follows, or occurs in the same position in the sort order as the other object.</summary>
+        /// <param name="obj">An object to compare with this instance.</param>
+        /// <exception cref="T:System.ArgumentException"><paramref name="obj" /> is not the same type as this instance.</exception>
+        public int CompareTo(object obj)
+        {
+            if (!(obj is ManagedEventHandler<TEventArgs> other))
+                throw new ArgumentException("Can't compare to an unrelated object type.");
+
+            int priorityCompare = this.Priority.CompareTo(other.Priority);
+            return priorityCompare != 0
+                ? priorityCompare
+                : this.RegistrationOrder.CompareTo(other.RegistrationOrder);
+        }
+    }
+}

--- a/src/SMAPI/Framework/Events/ModDisplayEvents.cs
+++ b/src/SMAPI/Framework/Events/ModDisplayEvents.cs
@@ -13,70 +13,70 @@ namespace StardewModdingAPI.Framework.Events
         /// <summary>Raised after a game menu is opened, closed, or replaced.</summary>
         public event EventHandler<MenuChangedEventArgs> MenuChanged
         {
-            add => this.EventManager.MenuChanged.Add(value);
+            add => this.EventManager.MenuChanged.Add(value, this.Mod);
             remove => this.EventManager.MenuChanged.Remove(value);
         }
 
         /// <summary>Raised before the game draws anything to the screen in a draw tick, as soon as the sprite batch is opened. The sprite batch may be closed and reopened multiple times after this event is called, but it's only raised once per draw tick. This event isn't useful for drawing to the screen, since the game will draw over it.</summary>
         public event EventHandler<RenderingEventArgs> Rendering
         {
-            add => this.EventManager.Rendering.Add(value);
+            add => this.EventManager.Rendering.Add(value, this.Mod);
             remove => this.EventManager.Rendering.Remove(value);
         }
 
         /// <summary>Raised after the game draws to the sprite patch in a draw tick, just before the final sprite batch is rendered to the screen. Since the game may open/close the sprite batch multiple times in a draw tick, the sprite batch may not contain everything being drawn and some things may already be rendered to the screen. Content drawn to the sprite batch at this point will be drawn over all vanilla content (including menus, HUD, and cursor).</summary>
         public event EventHandler<RenderedEventArgs> Rendered
         {
-            add => this.EventManager.Rendered.Add(value);
+            add => this.EventManager.Rendered.Add(value, this.Mod);
             remove => this.EventManager.Rendered.Remove(value);
         }
 
         /// <summary>Raised before the game world is drawn to the screen. This event isn't useful for drawing to the screen, since the game will draw over it.</summary>
         public event EventHandler<RenderingWorldEventArgs> RenderingWorld
         {
-            add => this.EventManager.RenderingWorld.Add(value);
+            add => this.EventManager.RenderingWorld.Add(value, this.Mod);
             remove => this.EventManager.RenderingWorld.Remove(value);
         }
 
         /// <summary>Raised after the game world is drawn to the sprite patch, before it's rendered to the screen. Content drawn to the sprite batch at this point will be drawn over the world, but under any active menu, HUD elements, or cursor.</summary>
         public event EventHandler<RenderedWorldEventArgs> RenderedWorld
         {
-            add => this.EventManager.RenderedWorld.Add(value);
+            add => this.EventManager.RenderedWorld.Add(value, this.Mod);
             remove => this.EventManager.RenderedWorld.Remove(value);
         }
 
         /// <summary>When a menu is open (<see cref="Game1.activeClickableMenu"/> isn't null), raised before that menu is drawn to the screen. This includes the game's internal menus like the title screen. Content drawn to the sprite batch at this point will appear under the menu.</summary>
         public event EventHandler<RenderingActiveMenuEventArgs> RenderingActiveMenu
         {
-            add => this.EventManager.RenderingActiveMenu.Add(value);
+            add => this.EventManager.RenderingActiveMenu.Add(value, this.Mod);
             remove => this.EventManager.RenderingActiveMenu.Remove(value);
         }
 
         /// <summary>When a menu is open (<see cref="Game1.activeClickableMenu"/> isn't null), raised after that menu is drawn to the sprite batch but before it's rendered to the screen. Content drawn to the sprite batch at this point will appear over the menu and menu cursor.</summary>
         public event EventHandler<RenderedActiveMenuEventArgs> RenderedActiveMenu
         {
-            add => this.EventManager.RenderedActiveMenu.Add(value);
+            add => this.EventManager.RenderedActiveMenu.Add(value, this.Mod);
             remove => this.EventManager.RenderedActiveMenu.Remove(value);
         }
 
         /// <summary>Raised before drawing the HUD (item toolbar, clock, etc) to the screen. The vanilla HUD may be hidden at this point (e.g. because a menu is open). Content drawn to the sprite batch at this point will appear under the HUD.</summary>
         public event EventHandler<RenderingHudEventArgs> RenderingHud
         {
-            add => this.EventManager.RenderingHud.Add(value);
+            add => this.EventManager.RenderingHud.Add(value, this.Mod);
             remove => this.EventManager.RenderingHud.Remove(value);
         }
 
         /// <summary>Raised after drawing the HUD (item toolbar, clock, etc) to the sprite batch, but before it's rendered to the screen. The vanilla HUD may be hidden at this point (e.g. because a menu is open). Content drawn to the sprite batch at this point will appear over the HUD.</summary>
         public event EventHandler<RenderedHudEventArgs> RenderedHud
         {
-            add => this.EventManager.RenderedHud.Add(value);
+            add => this.EventManager.RenderedHud.Add(value, this.Mod);
             remove => this.EventManager.RenderedHud.Remove(value);
         }
 
         /// <summary>Raised after the game window is resized.</summary>
         public event EventHandler<WindowResizedEventArgs> WindowResized
         {
-            add => this.EventManager.WindowResized.Add(value);
+            add => this.EventManager.WindowResized.Add(value, this.Mod);
             remove => this.EventManager.WindowResized.Remove(value);
         }
 

--- a/src/SMAPI/Framework/Events/ModGameLoopEvents.cs
+++ b/src/SMAPI/Framework/Events/ModGameLoopEvents.cs
@@ -12,84 +12,84 @@ namespace StardewModdingAPI.Framework.Events
         /// <summary>Raised after the game is launched, right before the first update tick.</summary>
         public event EventHandler<GameLaunchedEventArgs> GameLaunched
         {
-            add => this.EventManager.GameLaunched.Add(value);
+            add => this.EventManager.GameLaunched.Add(value, this.Mod);
             remove => this.EventManager.GameLaunched.Remove(value);
         }
 
         /// <summary>Raised before the game performs its overall update tick (≈60 times per second).</summary>
         public event EventHandler<UpdateTickingEventArgs> UpdateTicking
         {
-            add => this.EventManager.UpdateTicking.Add(value);
+            add => this.EventManager.UpdateTicking.Add(value, this.Mod);
             remove => this.EventManager.UpdateTicking.Remove(value);
         }
 
         /// <summary>Raised after the game performs its overall update tick (≈60 times per second).</summary>
         public event EventHandler<UpdateTickedEventArgs> UpdateTicked
         {
-            add => this.EventManager.UpdateTicked.Add(value);
+            add => this.EventManager.UpdateTicked.Add(value, this.Mod);
             remove => this.EventManager.UpdateTicked.Remove(value);
         }
 
         /// <summary>Raised once per second before the game state is updated.</summary>
         public event EventHandler<OneSecondUpdateTickingEventArgs> OneSecondUpdateTicking
         {
-            add => this.EventManager.OneSecondUpdateTicking.Add(value);
+            add => this.EventManager.OneSecondUpdateTicking.Add(value, this.Mod);
             remove => this.EventManager.OneSecondUpdateTicking.Remove(value);
         }
 
         /// <summary>Raised once per second after the game state is updated.</summary>
         public event EventHandler<OneSecondUpdateTickedEventArgs> OneSecondUpdateTicked
         {
-            add => this.EventManager.OneSecondUpdateTicked.Add(value);
+            add => this.EventManager.OneSecondUpdateTicked.Add(value, this.Mod);
             remove => this.EventManager.OneSecondUpdateTicked.Remove(value);
         }
 
         /// <summary>Raised before the game creates a new save file.</summary>
         public event EventHandler<SaveCreatingEventArgs> SaveCreating
         {
-            add => this.EventManager.SaveCreating.Add(value);
+            add => this.EventManager.SaveCreating.Add(value, this.Mod);
             remove => this.EventManager.SaveCreating.Remove(value);
         }
 
         /// <summary>Raised after the game finishes creating the save file.</summary>
         public event EventHandler<SaveCreatedEventArgs> SaveCreated
         {
-            add => this.EventManager.SaveCreated.Add(value);
+            add => this.EventManager.SaveCreated.Add(value, this.Mod);
             remove => this.EventManager.SaveCreated.Remove(value);
         }
 
         /// <summary>Raised before the game begins writes data to the save file.</summary>
         public event EventHandler<SavingEventArgs> Saving
         {
-            add => this.EventManager.Saving.Add(value);
+            add => this.EventManager.Saving.Add(value, this.Mod);
             remove => this.EventManager.Saving.Remove(value);
         }
 
         /// <summary>Raised after the game finishes writing data to the save file.</summary>
         public event EventHandler<SavedEventArgs> Saved
         {
-            add => this.EventManager.Saved.Add(value);
+            add => this.EventManager.Saved.Add(value, this.Mod);
             remove => this.EventManager.Saved.Remove(value);
         }
 
         /// <summary>Raised after the player loads a save slot and the world is initialized.</summary>
         public event EventHandler<SaveLoadedEventArgs> SaveLoaded
         {
-            add => this.EventManager.SaveLoaded.Add(value);
+            add => this.EventManager.SaveLoaded.Add(value, this.Mod);
             remove => this.EventManager.SaveLoaded.Remove(value);
         }
 
         /// <summary>Raised after the game begins a new day (including when the player loads a save).</summary>
         public event EventHandler<DayStartedEventArgs> DayStarted
         {
-            add => this.EventManager.DayStarted.Add(value);
+            add => this.EventManager.DayStarted.Add(value, this.Mod);
             remove => this.EventManager.DayStarted.Remove(value);
         }
 
         /// <summary>Raised before the game ends the current day. This happens before it starts setting up the next day and before <see cref="IGameLoopEvents.Saving"/>.</summary>
         public event EventHandler<DayEndingEventArgs> DayEnding
         {
-            add => this.EventManager.DayEnding.Add(value);
+            add => this.EventManager.DayEnding.Add(value, this.Mod);
             remove => this.EventManager.DayEnding.Remove(value);
         }
 
@@ -97,14 +97,14 @@ namespace StardewModdingAPI.Framework.Events
         public event EventHandler<TimeChangedEventArgs> TimeChanged
         {
 
-            add => this.EventManager.TimeChanged.Add(value);
+            add => this.EventManager.TimeChanged.Add(value, this.Mod);
             remove => this.EventManager.TimeChanged.Remove(value);
         }
 
         /// <summary>Raised after the game returns to the title screen.</summary>
         public event EventHandler<ReturnedToTitleEventArgs> ReturnedToTitle
         {
-            add => this.EventManager.ReturnedToTitle.Add(value);
+            add => this.EventManager.ReturnedToTitle.Add(value, this.Mod);
             remove => this.EventManager.ReturnedToTitle.Remove(value);
         }
 

--- a/src/SMAPI/Framework/Events/ModInputEvents.cs
+++ b/src/SMAPI/Framework/Events/ModInputEvents.cs
@@ -12,28 +12,28 @@ namespace StardewModdingAPI.Framework.Events
         /// <summary>Raised after the player presses a button on the keyboard, controller, or mouse.</summary>
         public event EventHandler<ButtonPressedEventArgs> ButtonPressed
         {
-            add => this.EventManager.ButtonPressed.Add(value);
+            add => this.EventManager.ButtonPressed.Add(value, this.Mod);
             remove => this.EventManager.ButtonPressed.Remove(value);
         }
 
         /// <summary>Raised after the player releases a button on the keyboard, controller, or mouse.</summary>
         public event EventHandler<ButtonReleasedEventArgs> ButtonReleased
         {
-            add => this.EventManager.ButtonReleased.Add(value);
+            add => this.EventManager.ButtonReleased.Add(value, this.Mod);
             remove => this.EventManager.ButtonReleased.Remove(value);
         }
 
         /// <summary>Raised after the player moves the in-game cursor.</summary>
         public event EventHandler<CursorMovedEventArgs> CursorMoved
         {
-            add => this.EventManager.CursorMoved.Add(value);
+            add => this.EventManager.CursorMoved.Add(value, this.Mod);
             remove => this.EventManager.CursorMoved.Remove(value);
         }
 
         /// <summary>Raised after the player scrolls the mouse wheel.</summary>
         public event EventHandler<MouseWheelScrolledEventArgs> MouseWheelScrolled
         {
-            add => this.EventManager.MouseWheelScrolled.Add(value);
+            add => this.EventManager.MouseWheelScrolled.Add(value, this.Mod);
             remove => this.EventManager.MouseWheelScrolled.Remove(value);
         }
 

--- a/src/SMAPI/Framework/Events/ModMultiplayerEvents.cs
+++ b/src/SMAPI/Framework/Events/ModMultiplayerEvents.cs
@@ -12,21 +12,21 @@ namespace StardewModdingAPI.Framework.Events
         /// <summary>Raised after the mod context for a peer is received. This happens before the game approves the connection, so the player doesn't yet exist in the game. This is the earliest point where messages can be sent to the peer via SMAPI.</summary>
         public event EventHandler<PeerContextReceivedEventArgs> PeerContextReceived
         {
-            add => this.EventManager.PeerContextReceived.Add(value);
+            add => this.EventManager.PeerContextReceived.Add(value, this.Mod);
             remove => this.EventManager.PeerContextReceived.Remove(value);
         }
 
         /// <summary>Raised after a mod message is received over the network.</summary>
         public event EventHandler<ModMessageReceivedEventArgs> ModMessageReceived
         {
-            add => this.EventManager.ModMessageReceived.Add(value);
+            add => this.EventManager.ModMessageReceived.Add(value, this.Mod);
             remove => this.EventManager.ModMessageReceived.Remove(value);
         }
 
         /// <summary>Raised after the connection with a peer is severed.</summary>
         public event EventHandler<PeerDisconnectedEventArgs> PeerDisconnected
         {
-            add => this.EventManager.PeerDisconnected.Add(value);
+            add => this.EventManager.PeerDisconnected.Add(value, this.Mod);
             remove => this.EventManager.PeerDisconnected.Remove(value);
         }
 

--- a/src/SMAPI/Framework/Events/ModPlayerEvents.cs
+++ b/src/SMAPI/Framework/Events/ModPlayerEvents.cs
@@ -12,21 +12,21 @@ namespace StardewModdingAPI.Framework.Events
         /// <summary>Raised after items are added or removed to a player's inventory. NOTE: this event is currently only raised for the local player.</summary>
         public event EventHandler<InventoryChangedEventArgs> InventoryChanged
         {
-            add => this.EventManager.InventoryChanged.Add(value);
+            add => this.EventManager.InventoryChanged.Add(value, this.Mod);
             remove => this.EventManager.InventoryChanged.Remove(value);
         }
 
         /// <summary>Raised after a player skill level changes. This happens as soon as they level up, not when the game notifies the player after their character goes to bed.  NOTE: this event is currently only raised for the local player.</summary>
         public event EventHandler<LevelChangedEventArgs> LevelChanged
         {
-            add => this.EventManager.LevelChanged.Add(value);
+            add => this.EventManager.LevelChanged.Add(value, this.Mod);
             remove => this.EventManager.LevelChanged.Remove(value);
         }
 
         /// <summary>Raised after a player warps to a new location. NOTE: this event is currently only raised for the local player.</summary>
         public event EventHandler<WarpedEventArgs> Warped
         {
-            add => this.EventManager.Warped.Add(value);
+            add => this.EventManager.Warped.Add(value, this.Mod);
             remove => this.EventManager.Warped.Remove(value);
         }
 

--- a/src/SMAPI/Framework/Events/ModSpecialisedEvents.cs
+++ b/src/SMAPI/Framework/Events/ModSpecialisedEvents.cs
@@ -12,21 +12,21 @@ namespace StardewModdingAPI.Framework.Events
         /// <summary>Raised when the low-level stage in the game's loading process has changed. This is an advanced event for mods which need to run code at specific points in the loading process. The available stages or when they happen might change without warning in future versions (e.g. due to changes in the game's load process), so mods using this event are more likely to break or have bugs. Most mods should use <see cref="IGameLoopEvents"/> instead.</summary>
         public event EventHandler<LoadStageChangedEventArgs> LoadStageChanged
         {
-            add => this.EventManager.LoadStageChanged.Add(value);
+            add => this.EventManager.LoadStageChanged.Add(value, this.Mod);
             remove => this.EventManager.LoadStageChanged.Remove(value);
         }
 
         /// <summary>Raised before the game state is updated (≈60 times per second), regardless of normal SMAPI validation. This event is not thread-safe and may be invoked while game logic is running asynchronously. Changes to game state in this method may crash the game or corrupt an in-progress save. Do not use this event unless you're fully aware of the context in which your code will be run. Mods using this event will trigger a stability warning in the SMAPI console.</summary>
         public event EventHandler<UnvalidatedUpdateTickingEventArgs> UnvalidatedUpdateTicking
         {
-            add => this.EventManager.UnvalidatedUpdateTicking.Add(value);
+            add => this.EventManager.UnvalidatedUpdateTicking.Add(value, this.Mod);
             remove => this.EventManager.UnvalidatedUpdateTicking.Remove(value);
         }
 
         /// <summary>Raised after the game state is updated (≈60 times per second), regardless of normal SMAPI validation. This event is not thread-safe and may be invoked while game logic is running asynchronously. Changes to game state in this method may crash the game or corrupt an in-progress save. Do not use this event unless you're fully aware of the context in which your code will be run. Mods using this event will trigger a stability warning in the SMAPI console.</summary>
         public event EventHandler<UnvalidatedUpdateTickedEventArgs> UnvalidatedUpdateTicked
         {
-            add => this.EventManager.UnvalidatedUpdateTicked.Add(value);
+            add => this.EventManager.UnvalidatedUpdateTicked.Add(value, this.Mod);
             remove => this.EventManager.UnvalidatedUpdateTicked.Remove(value);
         }
 

--- a/src/SMAPI/Framework/Events/ModWorldEvents.cs
+++ b/src/SMAPI/Framework/Events/ModWorldEvents.cs
@@ -40,28 +40,28 @@ namespace StardewModdingAPI.Framework.Events
         /// <summary>Raised after NPCs are added or removed in a location.</summary>
         public event EventHandler<NpcListChangedEventArgs> NpcListChanged
         {
-            add => this.EventManager.NpcListChanged.Add(value);
+            add => this.EventManager.NpcListChanged.Add(value, this.Mod);
             remove => this.EventManager.NpcListChanged.Remove(value);
         }
 
         /// <summary>Raised after objects are added or removed in a location.</summary>
         public event EventHandler<ObjectListChangedEventArgs> ObjectListChanged
         {
-            add => this.EventManager.ObjectListChanged.Add(value);
+            add => this.EventManager.ObjectListChanged.Add(value, this.Mod);
             remove => this.EventManager.ObjectListChanged.Remove(value);
         }
 
         /// <summary>Raised after items are added or removed from a chest.</summary>
         public event EventHandler<ChestInventoryChangedEventArgs> ChestInventoryChanged
         {
-            add => this.EventManager.ChestInventoryChanged.Add(value);
+            add => this.EventManager.ChestInventoryChanged.Add(value, this.Mod);
             remove => this.EventManager.ChestInventoryChanged.Remove(value);
         }
 
         /// <summary>Raised after terrain features (like floors and trees) are added or removed in a location.</summary>
         public event EventHandler<TerrainFeatureListChangedEventArgs> TerrainFeatureListChanged
         {
-            add => this.EventManager.TerrainFeatureListChanged.Add(value);
+            add => this.EventManager.TerrainFeatureListChanged.Add(value, this.Mod);
             remove => this.EventManager.TerrainFeatureListChanged.Remove(value);
         }
 

--- a/src/SMAPI/Framework/SCore.cs
+++ b/src/SMAPI/Framework/SCore.cs
@@ -172,7 +172,7 @@ namespace StardewModdingAPI.Framework
             this.MonitorForGame = this.GetSecondaryMonitor("game");
 
             SCore.PerformanceMonitor = new PerformanceMonitor(this.Monitor);
-            this.EventManager = new EventManager(this.Monitor, this.ModRegistry, SCore.PerformanceMonitor);
+            this.EventManager = new EventManager(this.ModRegistry, SCore.PerformanceMonitor);
             SCore.PerformanceMonitor.InitializePerformanceCounterCollections(this.EventManager);
 
             SCore.DeprecationManager = new DeprecationManager(this.Monitor, this.ModRegistry);

--- a/src/SMAPI/Framework/SGame.cs
+++ b/src/SMAPI/Framework/SGame.cs
@@ -240,7 +240,7 @@ namespace StardewModdingAPI.Framework
                 modIDs.Remove(message.FromModID); // don't send a broadcast back to the sender
 
             // raise events
-            this.Events.ModMessageReceived.RaiseForMods(new ModMessageReceivedEventArgs(message), mod => mod != null && modIDs.Contains(mod.Manifest.UniqueID));
+            this.Events.ModMessageReceived.Raise(new ModMessageReceivedEventArgs(message), mod => mod != null && modIDs.Contains(mod.Manifest.UniqueID));
         }
 
         /// <summary>A callback invoked when custom content is removed from the save data to avoid a crash.</summary>


### PR DESCRIPTION
Example mod:
```cs
using System;
using System.Collections.Generic;
using System.Linq;
using System.Text;
using System.Threading.Tasks;
using StardewModdingAPI;
using StardewModdingAPI.Events;

namespace DummyMod
{
    public class Mod : StardewModdingAPI.Mod
    {
        public override void Entry( IModHelper helper )
        {
            helper.Events.GameLoop.GameLaunched += GameLaunched_ImplicitNormal;
            helper.Events.GameLoop.GameLaunched += GameLaunched_Low;
            helper.Events.GameLoop.GameLaunched += GameLaunched_High;
            helper.Events.GameLoop.GameLaunched += GameLaunched_ExplicitNormal;
        }
        
        public void GameLaunched_ImplicitNormal(object sender, GameLaunchedEventArgs args)
        {
            Monitor.Log( "event: " + nameof( GameLaunched_ImplicitNormal ) );
        }

        [EventPriority( EventPriority.Normal )]
        public void GameLaunched_ExplicitNormal( object sender, GameLaunchedEventArgs args )
        {
            Monitor.Log( "event: " + nameof( GameLaunched_ExplicitNormal ) );
        }

        [EventPriority( EventPriority.Low )]
        public void GameLaunched_Low( object sender, GameLaunchedEventArgs args )
        {
            Monitor.Log( "event: " + nameof( GameLaunched_Low ) );
        }

        [EventPriority( EventPriority.High )]
        public void GameLaunched_High( object sender, GameLaunchedEventArgs args )
        {
            Monitor.Log( "event: " + nameof( GameLaunched_High ) );
        }
    }
}
```

Example [log](https://smapi.io/log/a89f59eeb4944e8ebde1ca830844a27b) (and corresponding snippet below):
```
15:27:19 | INFO | SMAPI | Type 'help' for help, or 'help <cmd>' for a command's usage
15:27:19 | TRACE | Dummy Mod | event: GameLaunched_High
15:27:19 | TRACE | Dummy Mod | event: GameLaunched_ImplicitNormal
15:27:19 | TRACE | Dummy Mod | event: GameLaunched_ExplicitNormal
15:27:19 | TRACE | Dummy Mod | event: GameLaunched_Low
```

It uses a stable sort (Enumerable.OrderBy, compared to Array.Sort) to maintain insertion order of event handlers to keep consistency with the current implementation.