### PR TITLE
Update smapi.targets so 0Harmony, MonoGame refs appear when intended

### DIFF
--- a/src/SMAPI.ModBuildConfig/build/smapi.targets
+++ b/src/SMAPI.ModBuildConfig/build/smapi.targets
@@ -20,12 +20,12 @@
     <ModZipPath Condition="'$(ModZipPath)' == ''">$(TargetDir)</ModZipPath>
     <EnableModDeploy Condition="'$(EnableModDeploy)' == ''">true</EnableModDeploy>
     <EnableModZip Condition="'$(EnableModZip)' == ''">true</EnableModZip>
-    <EnableHarmony Condition="'$(EnableModZip)' == ''">false</EnableHarmony>
+    <EnableHarmony Condition="'$(EnableHarmony)' == ''">false</EnableHarmony>
     <EnableGameDebugging Condition="$(EnableGameDebugging) == ''">true</EnableGameDebugging>
     <CopyModReferencesToBuildOutput Condition="'$(CopyModReferencesToBuildOutput)' == '' OR ('$(CopyModReferencesToBuildOutput)' != 'true' AND '$(CopyModReferencesToBuildOutput)' != 'false')">false</CopyModReferencesToBuildOutput>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(OS) == 'Windows_NT' AND $(EnableGameDebugging) == 'true'">
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT' AND $(EnableGameDebugging) == 'true'">
     <!-- enable game debugging -->
     <StartAction>Program</StartAction>
     <StartProgram>$(GamePath)\StardewModdingAPI.exe</StartProgram>
@@ -47,7 +47,7 @@
   </ItemGroup>
 
   <!-- Windows -->
-  <ItemGroup Condition="$(OS) == 'Windows_NT'">
+  <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
     <Reference Include="Microsoft.Xna.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86" Private="$(CopyModReferencesToBuildOutput)" />
     <Reference Include="Microsoft.Xna.Framework.Game, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86" Private="$(CopyModReferencesToBuildOutput)" />
     <Reference Include="Microsoft.Xna.Framework.Graphics, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86" Private="$(CopyModReferencesToBuildOutput)" />
@@ -56,7 +56,7 @@
   </ItemGroup>
 
   <!-- Linux/Mac -->
-  <ItemGroup Condition="$(OS) != 'Windows_NT'">
+  <ItemGroup Condition="'$(OS)' != 'Windows_NT'">
     <Reference Include="MonoGame.Framework" HintPath="$(GamePath)\MonoGame.Framework.dll" Private="$(CopyModReferencesToBuildOutput)" />
   </ItemGroup>
 


### PR DESCRIPTION
Bit of a shot in the dark here, because I haven't figured out how to get a new build of the package to test. But I found a few possible syntax issues... could these explain why references to 0Harmony and MonoGame keep re-appearing in my projects without ever enabling them and even after repeated deletion? 