### PR TITLE
Allow for negative values in Rectangle

### DIFF
--- a/src/SMAPI/Framework/Serialization/RectangleConverter.cs
+++ b/src/SMAPI/Framework/Serialization/RectangleConverter.cs
@@ -37,7 +37,7 @@ namespace StardewModdingAPI.Framework.Serialization
             if (string.IsNullOrWhiteSpace(str))
                 return Rectangle.Empty;
 
-            var match = Regex.Match(str, @"^\{X:(?<x>\d+) Y:(?<y>\d+) Width:(?<width>\d+) Height:(?<height>\d+)\}$", RegexOptions.IgnoreCase);
+            var match = Regex.Match(str, @"^\{X:(?<x>-?\d+) Y:(?<y>-?\d+) Width:(?<width>-?\d+) Height:(?<height>-?\d+)\}$", RegexOptions.IgnoreCase);
             if (!match.Success)
                 throw new SParseException($"Can't parse {nameof(Rectangle)} from invalid value '{str}' (path: {path}).");
 


### PR DESCRIPTION
Allow for negative values in Rectangle.
Rectangle parsing ("Windows format") currently fails when a value is negative.