### PR TITLE
Added Font loading to the ModContentManager

### DIFF
--- a/src/SMAPI/Framework/Serialization/SpriteFontData.cs
+++ b/src/SMAPI/Framework/Serialization/SpriteFontData.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace StardewModdingAPI.Framework.Serialization
+{
+    internal class SpriteFontData
+    {
+        public int LineSpacing { get; set; }
+        public float Spacing { get; set; }
+        public char? DefaultCharacter { get; set; }
+        public List<char> Characters { get; set; }
+        public Dictionary<char, SpriteFontGlyphData> Glyphs { get; set; }
+    }
+}

--- a/src/SMAPI/Framework/Serialization/SpriteFontGlyphData.cs
+++ b/src/SMAPI/Framework/Serialization/SpriteFontGlyphData.cs
@@ -1,0 +1,14 @@
+using Microsoft.Xna.Framework;
+
+namespace StardewModdingAPI.Framework.Serialization
+{
+    internal class SpriteFontGlyphData
+    {
+        public Rectangle BoundsInTexture { get; set; }
+        public Rectangle Cropping { get; set; }
+        public char Character { get; set; }
+        public float LeftSideBearing { get; set; }
+        public float Width { get; set; }
+        public float RightSideBearing { get; set; }
+    }
+}

--- a/src/SMAPI/SMAPI.csproj
+++ b/src/SMAPI/SMAPI.csproj
@@ -28,6 +28,7 @@
     <Reference Include="GalaxyCSharp" HintPath="$(GamePath)\GalaxyCSharp.dll" Private="False" />
     <Reference Include="Lidgren.Network" HintPath="$(GamePath)\Lidgren.Network.dll" Private="False" />
     <Reference Include="xTile" HintPath="$(GamePath)\xTile.dll" Private="False" />
+    <Reference Include="BmFont" HintPath="$(GamePath)\BmFont.dll" Private="False" />
   </ItemGroup>
 
   <Choose>


### PR DESCRIPTION
Allows this to work:
```
SpriteFont spriteFont = Helper.Content.Load<SpriteFont>(assetNameSpriteFont);
FontFile fontFile = Helper.Content.Load<FontFile>(assetNameFontFile);
List<Texture2D> fontFilePages = 
fontFile.Pages
.Select(p => Helper.Content.Load<Texture2D>(p.File, ContentSource.GameContent))
.ToList();
```
The game loads it's FontFile pages like this:
```
foreach (FontPage page in SpriteText.FontFile.Pages)
           SpriteText.fontPages.Add(Game1.content.Load<Texture2D>(string.Concat("Fonts\\", page.File)));
```
So it is to be noted that should this be used to replace vanilla fonts, the extra "Fonts" directory would need to be accounted for, which this does not.