### PR TITLE
Fix harmony attributes not working cross-platform (2)

### DIFF
--- a/src/SMAPI/Framework/ModLoading/AssemblyLoader.cs
+++ b/src/SMAPI/Framework/ModLoading/AssemblyLoader.cs
@@ -302,6 +302,11 @@ namespace StardewModdingAPI.Framework.ModLoading
                         {
                             if (conField.Value is TypeReference typeRef)
                                 this.ChangeTypeScope(typeRef);
+                            else if (conField.Value is TypeReference[] typeRefs)
+                            {
+                                foreach (var singleTypeRef in typeRefs)
+                                    this.ChangeTypeScope(singleTypeRef);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
While the previous PR fixed attributes of the form:

```c#
[HarmonyPatch( typeof( Fence ), nameof( Fence.repair ) )]
public static class FenceRepairPatch
{
// ...
}
```

It did NOT fix arrays of types in the attribute:

```c#
[HarmonyPatch( typeof( Fence ), MethodType.Constructor, new Type[] { typeof( Vector2 ), typeof( int ), typeof( bool ) } )]
public static class FenceConstructorPatch
{
// ...
}
```
Specifically, the Vector2 causes this error:
```
[22:39:13 ERROR Json Assets] Exception doing harmony stuff: System.TypeLoadException: Could not load type Microsoft.Xna.Framework.Vector2, Microsoft.Xna.Framework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553 while decoding custom attribute
  at (wrapper managed-to-native) System.MonoCustomAttrs:GetCustomAttributesInternal (System.Reflection.ICustomAttributeProvider,System.Type,bool)
  at System.MonoCustomAttrs.GetCustomAttributesBase (ICustomAttributeProvider obj, System.Type attributeType, Boolean inheritedOnly) <0x10cb26c70 + 0x00071> in <filename unknown>:0 
  at System.MonoCustomAttrs.GetCustomAttributes (ICustomAttributeProvider obj, System.Type attributeType, Boolean inherit) <0x10cb25e80 + 0x000bc> in <filename unknown>:0 
  at System.RuntimeType.GetCustomAttributes (Boolean inherit) <0x10cb597d0 + 0x0002f> in <filename unknown>:0 
  at Harmony.HarmonyMethodExtensions.GetHarmonyMethods (System.Type type) <0x17e7f8610 + 0x0001d> in <filename unknown>:0 
  at Harmony.HarmonyInstance.<PatchAll>b__9_0 (System.Type type) <0x17e7f84e0 + 0x00026> in <filename unknown>:0 
  at Harmony.CollectionExtensions.Do[T] (IEnumerable`1 sequence, System.Action`1 action) <0x11611a2b0 + 0x00088> in <filename unknown>:0 
  at Harmony.HarmonyInstance.PatchAll (System.Reflection.Assembly assembly) <0x17e7f83d0 + 0x000d4> in <filename unknown>:0 
  at Harmony.HarmonyInstance.PatchAll () <0x17e7f8320 + 0x00080> in <filename unknown>:0 
  at JsonAssets.Mod.Entry (IModHelper helper) <0x17e2f4ba0 + 0x01247> in <filename unknown>:0 
```

~~This should probably be tested before merging.~~ Json Assets (dev builds or from the GitHub repo) has both forms of patches (that is where the above code came from).