### PR TITLE
Fix strict Linux sandbox support in launcher

### DIFF
--- a/src/SMAPI.Installer/assets/unix-launcher.sh
+++ b/src/SMAPI.Installer/assets/unix-launcher.sh
@@ -80,8 +80,14 @@ else
         export LAUNCHTERM="$(basename "$(readlink -f $(COMMAND x-terminal-emulator))")"
     fi
 
-    # run in selected terminal and account for quirks
-    case $LAUNCHTERM in
+
+    if [ ! -x $LAUNCHTERM ]; then
+        echo "looks like found no terminal available for launch. maybe in sandbox or misconfigured system? fallbacking to execution without terminal"
+        export TERM="xterm"
+        exec $LAUNCHER $@
+    else
+        # run in selected terminal and account for quirks
+        case $LAUNCHTERM in
         terminal|termite)
             # LAUNCHTERM consumes only one argument after -e
             # options containing space characters are unsupported
@@ -110,5 +116,6 @@ else
             if [ $? -eq 127 ]; then
                 exec $LAUNCHER --no-terminal "$@"
             fi
-    esac
+        esac
+    fi
 fi


### PR DESCRIPTION
i added a check for is found terminal is executable.
game will launch with standart exec if found terminal is not exist or executable.

( fix for issue #775 )