### PR TITLE
Add `World.FurnitureListChanged` event

### DIFF
--- a/src/SMAPI/Events/FurnitureListChangedEventArgs.cs
+++ b/src/SMAPI/Events/FurnitureListChangedEventArgs.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using StardewValley;
 using StardewValley.Objects;
 

--- a/src/SMAPI/Events/FurnitureListChangedEventArgs.cs
+++ b/src/SMAPI/Events/FurnitureListChangedEventArgs.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using StardewValley;
+using StardewValley.Objects;
+
+namespace StardewModdingAPI.Events
+{
+    /// <summary>Event arguments for a <see cref="IWorldEvents.FurnitureListChanged"/> event.</summary>
+    public class FurnitureListChangedEventArgs : EventArgs
+    {
+        /*********
+        ** Accessors
+        *********/
+        /// <summary>The location which changed.</summary>
+        public GameLocation Location { get; }
+
+        /// <summary>The furniture added to the location.</summary>
+        public IEnumerable<Furniture> Added { get; }
+
+        /// <summary>The furniture removed from the location.</summary>
+        public IEnumerable<Furniture> Removed { get; }
+
+        /// <summary>Whether this is the location containing the local player.</summary>
+        public bool IsCurrentLocation => object.ReferenceEquals(this.Location, Game1.player?.currentLocation);
+
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Construct an instance.</summary>
+        /// <param name="location">The location which changed.</param>
+        /// <param name="added">The furniture added to the location.</param>
+        /// <param name="removed">The furniture removed from the location.</param>
+        internal FurnitureListChangedEventArgs(GameLocation location, IEnumerable<Furniture> added, IEnumerable<Furniture> removed)
+        {
+            this.Location = location;
+            this.Added = added.ToArray();
+            this.Removed = removed.ToArray();
+        }
+    }
+}

--- a/src/SMAPI/Events/IWorldEvents.cs
+++ b/src/SMAPI/Events/IWorldEvents.cs
@@ -28,5 +28,8 @@ namespace StardewModdingAPI.Events
 
         /// <summary>Raised after terrain features (like floors and trees) are added or removed in a location.</summary>
         event EventHandler<TerrainFeatureListChangedEventArgs> TerrainFeatureListChanged;
+
+        /// <summary>Raised after furniture are added or removed in a location.</summary>
+        event EventHandler<FurnitureListChangedEventArgs> FurnitureListChanged;
     }
 }

--- a/src/SMAPI/Framework/Events/EventManager.cs
+++ b/src/SMAPI/Framework/Events/EventManager.cs
@@ -162,6 +162,9 @@ namespace StardewModdingAPI.Framework.Events
         /// <summary>Raised after terrain features (like floors and trees) are added or removed in a location.</summary>
         public readonly ManagedEvent<TerrainFeatureListChangedEventArgs> TerrainFeatureListChanged;
 
+        /// <summary>Raised after furniture are added or removed in a location.</summary>
+        public readonly ManagedEvent<FurnitureListChangedEventArgs> FurnitureListChanged;
+
         /****
         ** Specialized
         ****/
@@ -238,6 +241,7 @@ namespace StardewModdingAPI.Framework.Events
             this.ObjectListChanged = ManageEventOf<ObjectListChangedEventArgs>(nameof(IModEvents.World), nameof(IWorldEvents.ObjectListChanged));
             this.ChestInventoryChanged = ManageEventOf<ChestInventoryChangedEventArgs>(nameof(IModEvents.World), nameof(IWorldEvents.ChestInventoryChanged));
             this.TerrainFeatureListChanged = ManageEventOf<TerrainFeatureListChangedEventArgs>(nameof(IModEvents.World), nameof(IWorldEvents.TerrainFeatureListChanged));
+            this.FurnitureListChanged = ManageEventOf<FurnitureListChangedEventArgs>(nameof(IModEvents.World), nameof(IWorldEvents.FurnitureListChanged));
 
             this.LoadStageChanged = ManageEventOf<LoadStageChangedEventArgs>(nameof(IModEvents.Specialized), nameof(ISpecializedEvents.LoadStageChanged));
             this.UnvalidatedUpdateTicking = ManageEventOf<UnvalidatedUpdateTickingEventArgs>(nameof(IModEvents.Specialized), nameof(ISpecializedEvents.UnvalidatedUpdateTicking), isPerformanceCritical: true);

--- a/src/SMAPI/Framework/Events/ModWorldEvents.cs
+++ b/src/SMAPI/Framework/Events/ModWorldEvents.cs
@@ -65,6 +65,13 @@ namespace StardewModdingAPI.Framework.Events
             remove => this.EventManager.TerrainFeatureListChanged.Remove(value);
         }
 
+        /// <summary>Raised after furniture are added or removed in a location.</summary>
+        public event EventHandler<FurnitureListChangedEventArgs> FurnitureListChanged
+        {
+            add => this.EventManager.FurnitureListChanged.Add(value, this.Mod);
+            remove => this.EventManager.FurnitureListChanged.Remove(value);
+        }
+
 
         /*********
         ** Public methods

--- a/src/SMAPI/Framework/SCore.cs
+++ b/src/SMAPI/Framework/SCore.cs
@@ -914,6 +914,10 @@ namespace StardewModdingAPI.Framework
                                 // terrain features changed
                                 if (locState.TerrainFeatures.IsChanged)
                                     events.TerrainFeatureListChanged.Raise(new TerrainFeatureListChangedEventArgs(location, locState.TerrainFeatures.Added, locState.TerrainFeatures.Removed));
+
+                                // furniture changed
+                                if (locState.Furniture.IsChanged)
+                                    events.FurnitureListChanged.Raise(new FurnitureListChangedEventArgs(location, locState.Furniture.Added, locState.Furniture.Removed));
                             }
                         }
 

--- a/src/SMAPI/Framework/StateTracking/LocationTracker.cs
+++ b/src/SMAPI/Framework/StateTracking/LocationTracker.cs
@@ -48,6 +48,9 @@ namespace StardewModdingAPI.Framework.StateTracking
         /// <summary>Tracks added or removed terrain features.</summary>
         public IDictionaryWatcher<Vector2, TerrainFeature> TerrainFeaturesWatcher { get; }
 
+        /// <summary>Tracks added or removed furniture.</summary>
+        public ICollectionWatcher<Furniture> FurnitureWatcher { get; }
+
         /// <summary>Tracks items added or removed to chests.</summary>
         public IDictionary<Vector2, ChestTracker> ChestWatchers { get; } = new Dictionary<Vector2, ChestTracker>();
 
@@ -68,6 +71,7 @@ namespace StardewModdingAPI.Framework.StateTracking
             this.NpcsWatcher = WatcherFactory.ForNetCollection(location.characters);
             this.ObjectsWatcher = WatcherFactory.ForNetDictionary(location.netObjects);
             this.TerrainFeaturesWatcher = WatcherFactory.ForNetDictionary(location.terrainFeatures);
+            this.FurnitureWatcher = WatcherFactory.ForNetCollection(location.furniture);
 
             this.Watchers.AddRange(new IWatcher[]
             {
@@ -76,7 +80,8 @@ namespace StardewModdingAPI.Framework.StateTracking
                 this.LargeTerrainFeaturesWatcher,
                 this.NpcsWatcher,
                 this.ObjectsWatcher,
-                this.TerrainFeaturesWatcher
+                this.TerrainFeaturesWatcher,
+                this.FurnitureWatcher
             });
 
             this.UpdateChestWatcherList(added: location.Objects.Pairs, removed: new KeyValuePair<Vector2, SObject>[0]);

--- a/src/SMAPI/Framework/StateTracking/Snapshots/LocationSnapshot.cs
+++ b/src/SMAPI/Framework/StateTracking/Snapshots/LocationSnapshot.cs
@@ -34,6 +34,9 @@ namespace StardewModdingAPI.Framework.StateTracking.Snapshots
         /// <summary>Tracks added or removed terrain features.</summary>
         public SnapshotListDiff<KeyValuePair<Vector2, TerrainFeature>> TerrainFeatures { get; } = new SnapshotListDiff<KeyValuePair<Vector2, TerrainFeature>>();
 
+        /// <summary>Tracks added or removed furniture.</summary>
+        public SnapshotListDiff<Furniture> Furniture { get; } = new SnapshotListDiff<Furniture>();
+
         /// <summary>Tracks changed chest inventories.</summary>
         public IDictionary<Chest, SnapshotItemListDiff> ChestItems { get; } = new Dictionary<Chest, SnapshotItemListDiff>();
 
@@ -59,6 +62,7 @@ namespace StardewModdingAPI.Framework.StateTracking.Snapshots
             this.Npcs.Update(watcher.NpcsWatcher);
             this.Objects.Update(watcher.ObjectsWatcher);
             this.TerrainFeatures.Update(watcher.TerrainFeaturesWatcher);
+            this.Furniture.Update(watcher.FurnitureWatcher);
 
             // chest inventories
             this.ChestItems.Clear();


### PR DESCRIPTION
Create a new event available to SMAPI mods to track furniture changes. To facilitate the event, a `FurnitureListChangedEventArgs` class is added as well.

Like other events, in SMAPI mods this is listened to with the syntax:
```cs
this.Helper.Events.World.FurnitureListChanged += delegate(object sender, FurnitureListChangedEventArgs e) { };
```
where `FurnitureListChangedEventArgs` has the properties:
`e.Location`: The location where the change occurred.
`e.Added`: The furniture added to the location.
`e.Removed`: The furniture removed from the location.

Fixes #778