### PR TITLE
Fix build error in MonoDevelop

### DIFF
--- a/src/SMAPI/Framework/Logging/LogManager.cs
+++ b/src/SMAPI/Framework/Logging/LogManager.cs
@@ -258,7 +258,7 @@ namespace StardewModdingAPI.Framework.Logging
                     break;
 
                 // path too long exception
-                case PathTooLongException:
+                case PathTooLongException _:
                     {
                         string[] affectedPaths = PathUtilities.GetTooLongPaths(Constants.ModsPath).ToArray();
                         string message = affectedPaths.Any()


### PR DESCRIPTION
`LogManager` contained a case statement that supplied only an exception type, which is incompatible with Mono on Linux. This change adds a discard variable for the exception.