### PR TITLE
Add an option to world_clear that leaves permanent objects alone

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -5,6 +5,7 @@
 * For players:
   * Added error if the wrong SMAPI bitness is installed (e.g. 32-bit SMAPI with 64-bit game).
   * Added error if some SMAPI files aren't updated correctly.
+  * Added `removeable` option to `world_clear`
   * Fixed intermittent error if a mod fetches mod-provided APIs asynchronously.
 
 * For mod authors:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -5,7 +5,7 @@
 * For players:
   * Added error if the wrong SMAPI bitness is installed (e.g. 32-bit SMAPI with 64-bit game).
   * Added error if some SMAPI files aren't updated correctly.
-  * Added `removeable` option to `world_clear`
+  * Added `removable` option to the `world_clear` console command (thanks to bladeoflight16!).
   * Fixed intermittent error if a mod fetches mod-provided APIs asynchronously.
 
 * For mod authors:

--- a/src/SMAPI.Mods.ConsoleCommands/Framework/Commands/World/ClearCommand.cs
+++ b/src/SMAPI.Mods.ConsoleCommands/Framework/Commands/World/ClearCommand.cs
@@ -15,7 +15,7 @@ namespace StardewModdingAPI.Mods.ConsoleCommands.Framework.Commands.World
         ** Fields
         *********/
         /// <summary>The valid types that can be cleared.</summary>
-        private readonly string[] ValidTypes = { "crops", "debris", "fruit-trees", "furniture", "grass", "trees", "removeable", "everything" };
+        private readonly string[] ValidTypes = { "crops", "debris", "fruit-trees", "furniture", "grass", "trees", "removable", "everything" };
 
         /// <summary>The resource clump IDs to consider debris.</summary>
         private readonly int[] DebrisClumps = { ResourceClump.stumpIndex, ResourceClump.hollowLogIndex, ResourceClump.meteoriteIndex, ResourceClump.boulderIndex };
@@ -31,7 +31,7 @@ namespace StardewModdingAPI.Mods.ConsoleCommands.Framework.Commands.World
                 description: "Clears in-game entities in a given location.\n\n"
                     + "Usage: world_clear <location> <object type>\n"
                     + " - location: the location name for which to clear objects (like Farm), or 'current' for the current location.\n"
-                    + " - object type: the type of object clear. You can specify 'crops', 'debris' (stones/twigs/weeds and dead crops), 'furniture', 'grass', and 'trees' / 'fruit-trees'. You can also specify 'removeable', which includes everything that can be removed or destroyed during normal game play, or 'everything', which includes permanent bushes."
+                    + " - object type: the type of object clear. You can specify 'crops', 'debris' (stones/twigs/weeds and dead crops), 'furniture', 'grass', and 'trees' / 'fruit-trees'. You can also specify 'removable' (remove everything that can be removed or destroyed during normal gameplay) or 'everything' (remove everything including permanent bushes)."
             )
         { }
 
@@ -133,25 +133,15 @@ namespace StardewModdingAPI.Mods.ConsoleCommands.Framework.Commands.World
                         break;
                     }
 
-                case "removeable":
-                    {
-                        int removed =
-                            this.RemoveFurniture(location, p => true)
-                            + this.RemoveObjects(location, p => true)
-                            + this.RemoveTerrainFeatures(location, p => true)
-                            + this.RemoveLargeTerrainFeatures(location, p => !(p is Bush) || ((Bush)p).isDestroyable(location, p.currentTileLocation))
-                            + this.RemoveResourceClumps(location, p => true);
-                        monitor.Log($"Done! Removed {removed} entities from {location.Name}.", LogLevel.Info);
-                        break;
-                    }
-
+                case "removable":
                 case "everything":
                     {
+                        bool everything = type == "everything";
                         int removed =
                             this.RemoveFurniture(location, p => true)
                             + this.RemoveObjects(location, p => true)
                             + this.RemoveTerrainFeatures(location, p => true)
-                            + this.RemoveLargeTerrainFeatures(location, p => true)
+                            + this.RemoveLargeTerrainFeatures(location, p => everything || p is not Bush bush || bush.isDestroyable(location, p.currentTileLocation))
                             + this.RemoveResourceClumps(location, p => true);
                         monitor.Log($"Done! Removed {removed} entities from {location.Name}.", LogLevel.Info);
                         break;

--- a/src/SMAPI.Mods.ConsoleCommands/Framework/Commands/World/ClearCommand.cs
+++ b/src/SMAPI.Mods.ConsoleCommands/Framework/Commands/World/ClearCommand.cs
@@ -15,7 +15,7 @@ namespace StardewModdingAPI.Mods.ConsoleCommands.Framework.Commands.World
         ** Fields
         *********/
         /// <summary>The valid types that can be cleared.</summary>
-        private readonly string[] ValidTypes = { "crops", "debris", "fruit-trees", "furniture", "grass", "trees", "everything" };
+        private readonly string[] ValidTypes = { "crops", "debris", "fruit-trees", "furniture", "grass", "trees", "removeable", "everything" };
 
         /// <summary>The resource clump IDs to consider debris.</summary>
         private readonly int[] DebrisClumps = { ResourceClump.stumpIndex, ResourceClump.hollowLogIndex, ResourceClump.meteoriteIndex, ResourceClump.boulderIndex };
@@ -30,8 +30,8 @@ namespace StardewModdingAPI.Mods.ConsoleCommands.Framework.Commands.World
                 name: "world_clear",
                 description: "Clears in-game entities in a given location.\n\n"
                     + "Usage: world_clear <location> <object type>\n"
-                    + " - object type: the type of object clear. You can specify 'crops', 'debris' (stones/twigs/weeds and dead crops), 'furniture', 'grass', and 'trees' / 'fruit-trees'. You can also specify 'everything', which includes things not removed by the other types (like resource clumps)."
                     + " - location: the location name for which to clear objects (like Farm), or 'current' for the current location.\n"
+                    + " - object type: the type of object clear. You can specify 'crops', 'debris' (stones/twigs/weeds and dead crops), 'furniture', 'grass', and 'trees' / 'fruit-trees'. You can also specify 'removeable', which includes everything that can be removed or destroyed during normal game play, or 'everything', which includes permanent bushes."
             )
         { }
 
@@ -129,6 +129,18 @@ namespace StardewModdingAPI.Mods.ConsoleCommands.Framework.Commands.World
                 case "trees":
                     {
                         int removed = this.RemoveTerrainFeatures(location, feature => feature is Tree);
+                        monitor.Log($"Done! Removed {removed} entities from {location.Name}.", LogLevel.Info);
+                        break;
+                    }
+
+                case "removeable":
+                    {
+                        int removed =
+                            this.RemoveFurniture(location, p => true)
+                            + this.RemoveObjects(location, p => true)
+                            + this.RemoveTerrainFeatures(location, p => true)
+                            + this.RemoveLargeTerrainFeatures(location, p => !(p is Bush) || ((Bush)p).isDestroyable(location, p.currentTileLocation))
+                            + this.RemoveResourceClumps(location, p => true);
                         monitor.Log($"Done! Removed {removed} entities from {location.Name}.", LogLevel.Info);
                         break;
                     }

--- a/src/SMAPI.Mods.ConsoleCommands/Framework/Commands/World/ClearCommand.cs
+++ b/src/SMAPI.Mods.ConsoleCommands/Framework/Commands/World/ClearCommand.cs
@@ -30,8 +30,8 @@ namespace StardewModdingAPI.Mods.ConsoleCommands.Framework.Commands.World
                 name: "world_clear",
                 description: "Clears in-game entities in a given location.\n\n"
                     + "Usage: world_clear <location> <object type>\n"
-                    + "- location: the location name for which to clear objects (like Farm), or 'current' for the current location.\n"
                     + " - object type: the type of object clear. You can specify 'crops', 'debris' (stones/twigs/weeds and dead crops), 'furniture', 'grass', and 'trees' / 'fruit-trees'. You can also specify 'everything', which includes things not removed by the other types (like resource clumps)."
+                    + " - location: the location name for which to clear objects (like Farm), or 'current' for the current location.\n"
             )
         { }
 

--- a/src/SMAPI.sln.DotSettings
+++ b/src/SMAPI.sln.DotSettings
@@ -36,6 +36,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fallbacks/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=filenames/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=gamepad/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=gameplay/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Hangfire/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=initializers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Junimo/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
The `everything` mode of `world_clear` removes walnut and berry bushes, important game features that cannot be recovered in normal gameplay or through any SMAPI commands. This change adds a new mode called `removeable`, which removes everything except these permanent objects that cannot be destroyed through normal game play.

Any feedback or requests for revisions are welcome. Particularly name changes or text rewording; I tend to be overly wordy.

Completely incidentally, this change also removes the now incorrect reference to other modes not removing resource clumps. (The `debris` mode *does* remove resource clumps.)