### PR TITLE
Fix Mono build error and duplicate targets import

### DIFF
--- a/src/SMAPI.Internal.Patching/PatchHelper.cs
+++ b/src/SMAPI.Internal.Patching/PatchHelper.cs
@@ -43,7 +43,7 @@ namespace StardewModdingAPI.Internal.Patching
         /// <param name="generics">The method generic types, or <c>null</c> if it's not generic.</param>
         public static string GetMethodString(Type type, string name, Type[] parameters = null, Type[] generics = null)
         {
-            StringBuilder str = new();
+            StringBuilder str = new StringBuilder();
 
             // type
             str.Append(type.FullName);

--- a/src/SMAPI.Toolkit/SMAPI.Toolkit.csproj
+++ b/src/SMAPI.Toolkit/SMAPI.Toolkit.csproj
@@ -19,6 +19,4 @@
   <ItemGroup>
     <ProjectReference Include="..\SMAPI.Toolkit.CoreInterfaces\SMAPI.Toolkit.CoreInterfaces.csproj" />
   </ItemGroup>
-
-  <Import Project="..\..\build\common.targets" />
 </Project>


### PR DESCRIPTION
Mono does not yet support C# 9 target-typed construction (see [new operator](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/new-operator)), causing build failures both in MonoDevelop and at the command line.

SMAPI.Toolkit.csproj imported common.targets twice, resulting in numerous (repeated 5 times in some cases) but harmless warnings about being unable to import it the second time. I removed the latter copy of the import, in case the earlier one is needed for any of the following package references.