### PR TITLE
Auto-complete support for the console

### DIFF
--- a/src/SMAPI/Framework/Command.cs
+++ b/src/SMAPI/Framework/Command.cs
@@ -20,6 +20,9 @@ namespace StardewModdingAPI.Framework
         /// <summary>The method to invoke when the command is triggered. This method is passed the command name and arguments submitted by the user.</summary>
         public Action<string, string[]> Callback { get; }
 
+        /// <summary>The method to invoke for auto-complete handling. This method is passed the current input, and should return the potential matches.</summary>
+        public Func<string, string[]> AutoCompleteHandler { get; }
+
 
         /*********
         ** Public methods
@@ -29,12 +32,13 @@ namespace StardewModdingAPI.Framework
         /// <param name="name">The command name, which the user must type to trigger it.</param>
         /// <param name="documentation">The human-readable documentation shown when the player runs the built-in 'help' command.</param>
         /// <param name="callback">The method to invoke when the command is triggered. This method is passed the command name and arguments submitted by the user.</param>
-        public Command(IModMetadata mod, string name, string documentation, Action<string, string[]> callback)
+        public Command(IModMetadata mod, string name, string documentation, Action<string, string[]> callback, Func<string, string[]> autoCompleteHandler)
         {
             this.Mod = mod;
             this.Name = name;
             this.Documentation = documentation;
             this.Callback = callback;
+            this.AutoCompleteHandler = autoCompleteHandler;
         }
     }
 }

--- a/src/SMAPI/Framework/Command.cs
+++ b/src/SMAPI/Framework/Command.cs
@@ -20,8 +20,8 @@ namespace StardewModdingAPI.Framework
         /// <summary>The method to invoke when the command is triggered. This method is passed the command name and arguments submitted by the user.</summary>
         public Action<string, string[]> Callback { get; }
 
-        /// <summary>The method to invoke for auto-complete handling. This method is passed the current input, and should return the potential matches.</summary>
-        public Func<string, string[]> AutoCompleteHandler { get; }
+        /// <summary>The method to invoke for auto-complete handling. This method is passed the command name and current input, and should return the potential matches.</summary>
+        public Func<string, string, string[]> AutoCompleteHandler { get; }
 
 
         /*********
@@ -32,7 +32,7 @@ namespace StardewModdingAPI.Framework
         /// <param name="name">The command name, which the user must type to trigger it.</param>
         /// <param name="documentation">The human-readable documentation shown when the player runs the built-in 'help' command.</param>
         /// <param name="callback">The method to invoke when the command is triggered. This method is passed the command name and arguments submitted by the user.</param>
-        public Command(IModMetadata mod, string name, string documentation, Action<string, string[]> callback, Func<string, string[]> autoCompleteHandler)
+        public Command(IModMetadata mod, string name, string documentation, Action<string, string[]> callback, Func<string, string, string[]> autoCompleteHandler)
         {
             this.Mod = mod;
             this.Name = name;

--- a/src/SMAPI/Framework/CommandManager.cs
+++ b/src/SMAPI/Framework/CommandManager.cs
@@ -36,10 +36,11 @@ namespace StardewModdingAPI.Framework
         /// <param name="documentation">The human-readable documentation shown when the player runs the built-in 'help' command.</param>
         /// <param name="callback">The method to invoke when the command is triggered. This method is passed the command name and arguments submitted by the user.</param>
         /// <param name="allowNullCallback">Whether to allow a null <paramref name="callback"/> argument; this should only used for backwards compatibility.</param>
+        /// <param name="autoCompleteHandler">The method to invoke for auto-complete handling. This method is passed the command name and current input, and should return the potential matches.</param>
         /// <exception cref="ArgumentNullException">The <paramref name="name"/> or <paramref name="callback"/> is null or empty.</exception>
         /// <exception cref="FormatException">The <paramref name="name"/> is not a valid format.</exception>
         /// <exception cref="ArgumentException">There's already a command with that name.</exception>
-        public CommandManager Add(IModMetadata mod, string name, string documentation, Action<string, string[]> callback, bool allowNullCallback = false, Func<string, string[]> autoCompleteHandler = null)
+        public CommandManager Add(IModMetadata mod, string name, string documentation, Action<string, string[]> callback, bool allowNullCallback = false, Func<string, string, string[]> autoCompleteHandler = null)
         {
             name = this.GetNormalizedName(name);
 
@@ -66,7 +67,7 @@ namespace StardewModdingAPI.Framework
         /// <exception cref="ArgumentException">There's already a command with that name.</exception>
         public CommandManager Add(IInternalCommand command, IMonitor monitor)
         {
-            return this.Add(null, command.Name, command.Description, (name, args) => command.HandleCommand(args, monitor), autoCompleteHandler: command.HandleAutoCompletion);
+            return this.Add(null, command.Name, command.Description, (name, args) => command.HandleCommand(args, monitor), autoCompleteHandler: (name, input) => command.HandleAutoCompletion(input));
         }
 
         /// <summary>Get a command by its unique name.</summary>
@@ -190,7 +191,7 @@ namespace StardewModdingAPI.Framework
                 // Take out the command name and space from what we pass to the command's auto-complete handler
                 text = text.Substring(space + 1);
 
-                return cmd.AutoCompleteHandler.Invoke(text);
+                return cmd.AutoCompleteHandler.Invoke(currCmdName, text);
             }
         }
 

--- a/src/SMAPI/Framework/CommandManager.cs
+++ b/src/SMAPI/Framework/CommandManager.cs
@@ -177,7 +177,7 @@ namespace StardewModdingAPI.Framework
                 foreach (string key in this.Commands.Keys)
                 {
                     if (key.StartsWith(text))
-                        matches.Add(key.Substring(text.Length));
+                        matches.Add(key);
                 }
                 return matches.ToArray();
             }

--- a/src/SMAPI/Framework/Commands/HarmonySummaryCommand.cs
+++ b/src/SMAPI/Framework/Commands/HarmonySummaryCommand.cs
@@ -62,6 +62,12 @@ namespace StardewModdingAPI.Framework.Commands
             monitor.Log(result.ToString().TrimEnd(), LogLevel.Info);
         }
 
+        /// <inheritdoc/>
+        public string[] HandleAutoCompletion( string currInput )
+        {
+            return null;
+        }
+
 
         /*********
         ** Private methods

--- a/src/SMAPI/Framework/Commands/HelpCommand.cs
+++ b/src/SMAPI/Framework/Commands/HelpCommand.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 
 namespace StardewModdingAPI.Framework.Commands
@@ -71,6 +72,25 @@ namespace StardewModdingAPI.Framework.Commands
 
                 monitor.Log(message, LogLevel.Info);
             }
+        }
+
+        /// <inheritdoc/>
+        public string[] HandleAutoCompletion( string currInput )
+        {
+            // If this is true, then they already entered an argument.
+            // This command only accepts one argument, so we are done.
+            if ( currInput.Contains( ' ' ) )
+                return null;
+
+            var allCommandNames = this.CommandManager.GetAll().Select( ( cmd ) => cmd.Name );
+
+            List<string> ret = new List<string>();
+            foreach ( string cmdName in allCommandNames )
+            {
+                if ( cmdName.StartsWith( currInput ) )
+                    ret.Add( cmdName );
+            }
+            return ret.ToArray();
         }
     }
 }

--- a/src/SMAPI/Framework/Commands/IInternalCommand.cs
+++ b/src/SMAPI/Framework/Commands/IInternalCommand.cs
@@ -20,5 +20,10 @@ namespace StardewModdingAPI.Framework.Commands
         /// <param name="args">The command arguments.</param>
         /// <param name="monitor">Writes messages to the console.</param>
         void HandleCommand(string[] args, IMonitor monitor);
+
+        /// <summary>Handle the auto-completion fir this command based on the current input.</summary>
+        /// <param name="currInput">The current input.</param>
+        /// <returns>Suggested auto-completions to cycle through.</returns>
+        string[] HandleAutoCompletion( string currInput );
     }
 }

--- a/src/SMAPI/Framework/Commands/ReloadI18nCommand.cs
+++ b/src/SMAPI/Framework/Commands/ReloadI18nCommand.cs
@@ -40,5 +40,11 @@ namespace StardewModdingAPI.Framework.Commands
             this.ReloadTranslations();
             monitor.Log("Reloaded translation files for all mods. This only affects new translations the mods fetch; if they cached some text, it may not be updated.", LogLevel.Info);
         }
+
+        /// <inheritdoc/>
+        public string[] HandleAutoCompletion( string currInput )
+        {
+            return null;
+        }
     }
 }

--- a/src/SMAPI/Framework/Logging/LogManager.cs
+++ b/src/SMAPI/Framework/Logging/LogManager.cs
@@ -64,6 +64,9 @@ namespace StardewModdingAPI.Framework.Logging
             )
         };
 
+        /// <summary>The original Console.Out</summary>
+        private readonly TextWriter OriginalConsoleOut;
+
 
         /*********
         ** Accessors
@@ -102,6 +105,7 @@ namespace StardewModdingAPI.Framework.Logging
             this.LogFile = new LogFileManager(logPath);
             this.Monitor = this.GetMonitor("SMAPI");
             this.MonitorForGame = this.GetMonitor("game");
+            this.OriginalConsoleOut = Console.Out;
 
             // redirect direct console output
             var output = new InterceptingTextWriter(Console.Out, this.IgnoreChar);
@@ -142,13 +146,16 @@ namespace StardewModdingAPI.Framework.Logging
                 .Add(new HarmonySummaryCommand(), this.Monitor)
                 .Add(new ReloadI18nCommand(reloadTranslations), this.Monitor);
 
+            ReadLine.ReadLine.Instance.AutoCompletionHandler = commandManager;
+            ReadLine.ReadLine.Instance.WriteFunction = ( str ) => this.OriginalConsoleOut.Write( str );
+
             // start handling command line input
             Thread inputThread = new Thread(() =>
             {
                 while (true)
                 {
                     // get input
-                    string input = Console.ReadLine();
+                    string input = ReadLine.ReadLine.Instance.Read();
                     if (string.IsNullOrWhiteSpace(input))
                         continue;
 

--- a/src/SMAPI/Framework/ModHelpers/CommandHelper.cs
+++ b/src/SMAPI/Framework/ModHelpers/CommandHelper.cs
@@ -36,7 +36,7 @@ namespace StardewModdingAPI.Framework.ModHelpers
         }
         
         /// <inheritdoc />
-        public ICommandHelper Add(string name, string documentation, Action<string, string[]> callback, Func<string, string[]> autoCompleteHandler)
+        public ICommandHelper Add(string name, string documentation, Action<string, string[]> callback, Func<string, string, string[]> autoCompleteHandler)
         {
             this.CommandManager.Add(this.Mod, name, documentation, callback, autoCompleteHandler: autoCompleteHandler);
             return this;

--- a/src/SMAPI/Framework/ModHelpers/CommandHelper.cs
+++ b/src/SMAPI/Framework/ModHelpers/CommandHelper.cs
@@ -34,6 +34,13 @@ namespace StardewModdingAPI.Framework.ModHelpers
             this.CommandManager.Add(this.Mod, name, documentation, callback);
             return this;
         }
+        
+        /// <inheritdoc />
+        public ICommandHelper Add(string name, string documentation, Action<string, string[]> callback, Func<string, string[]> autoCompleteHandler)
+        {
+            this.CommandManager.Add(this.Mod, name, documentation, callback, autoCompleteHandler: autoCompleteHandler);
+            return this;
+        }
 
         /// <inheritdoc />
         [Obsolete]

--- a/src/SMAPI/Framework/SCore.cs
+++ b/src/SMAPI/Framework/SCore.cs
@@ -519,7 +519,7 @@ namespace StardewModdingAPI.Framework
                     {
                         if (!this.CommandManager.TryParse(rawInput, out name, out args, out command, out screenId))
                         {
-                            this.Monitor.Log("Unknown command; type 'help' for a list of available commands.", LogLevel.Error);
+                            this.Monitor.Log($"Unknown command '{name}'; type 'help' for a list of available commands.", LogLevel.Error);
                             continue;
                         }
                     }

--- a/src/SMAPI/ICommandHelper.cs
+++ b/src/SMAPI/ICommandHelper.cs
@@ -17,6 +17,16 @@ namespace StardewModdingAPI
         /// <exception cref="ArgumentException">There's already a command with that name.</exception>
         ICommandHelper Add(string name, string documentation, Action<string, string[]> callback);
 
+        /// <summary>Add a console command.</summary>
+        /// <param name="name">The command name, which the user must type to trigger it.</param>
+        /// <param name="documentation">The human-readable documentation shown when the player runs the built-in 'help' command.</param>
+        /// <param name="callback">The method to invoke when the command is triggered. This method is passed the command name and arguments submitted by the user.</param>
+        /// <param name="autoCompleteHandler">The method to invoke for auto-complete handling. This method is passed the command name and current input, and should return the potential matches.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="name"/> or <paramref name="callback"/> is null or empty.</exception>
+        /// <exception cref="FormatException">The <paramref name="name"/> is not a valid format.</exception>
+        /// <exception cref="ArgumentException">There's already a command with that name.</exception>
+        public ICommandHelper Add(string name, string documentation, Action<string, string[]> callback, Func<string, string, string[]> autoCompleteHandler);
+
         /// <summary>Trigger a command.</summary>
         /// <param name="name">The command name.</param>
         /// <param name="arguments">The command arguments.</param>

--- a/src/SMAPI/SMAPI.csproj
+++ b/src/SMAPI/SMAPI.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="MonoMod.Common" Version="21.6.21.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Platonymous.TMXTile" Version="1.5.8" />
-    <PackageReference Include="spacechase0.ReadLine.SMAPI" Version="2.2.0" />
+    <PackageReference Include="spacechase0.ReadLine.SMAPI" Version="2.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SMAPI/SMAPI.csproj
+++ b/src/SMAPI/SMAPI.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="MonoMod.Common" Version="21.6.21.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Platonymous.TMXTile" Version="1.5.8" />
-    <PackageReference Include="spacechase0.ReadLine" Version="2.2.0" />
+    <PackageReference Include="spacechase0.ReadLine.SMAPI" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SMAPI/SMAPI.csproj
+++ b/src/SMAPI/SMAPI.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="MonoMod.Common" Version="21.6.21.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Platonymous.TMXTile" Version="1.5.8" />
+    <PackageReference Include="spacechase0.ReadLine" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SMAPI/SMAPI.csproj
+++ b/src/SMAPI/SMAPI.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="MonoMod.Common" Version="21.6.21.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Platonymous.TMXTile" Version="1.5.8" />
-    <PackageReference Include="spacechase0.ReadLine.SMAPI" Version="2.2.1" />
+    <PackageReference Include="spacechase0.ReadLine.SMAPI" Version="2.2.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
(And a bunch of other stuff, included in the ReadLine library. See GitHub page. Only tab completion and history was tested.)

Uses the ReadLine library, with some tweaks I had to do for SMAPI:
<https://www.nuget.org/packages/spacechase0.ReadLine.SMAPI/2.2.0>
Fork: <https://github.com/spacechase0/ReadLine> (and relevant commit: <https://github.com/spacechase0/ReadLine/commit/e5eaa386f55bcd153c36d796150daf96ff6b7973> )

Includes support for commands names themselves (handled by SMAPI) and the `help` built-in command, + API for mods to handle auto-completion for their commands.

Mods can pass a new parameter, a function taking a `string` representing the current input and returning `string[]` representing the list of potential completions. For an example, see SMAPI's `help` command (since they function the same).

(I'd normally include a GIF here, but the GIF has some unreleased stuff of mine in it.)