### PR TITLE
fix for .NET 6

### DIFF
--- a/src/SMAPI.Installer/assets/runtimeconfig.unix.json
+++ b/src/SMAPI.Installer/assets/runtimeconfig.unix.json
@@ -1,6 +1,7 @@
 {
     "runtimeOptions": {
         "tfm": "net5.0",
+        "rollForward": "LatestMajor",
         "includedFrameworks": [
             {
                 "name": "Microsoft.NETCore.App",

--- a/src/SMAPI.Installer/assets/runtimeconfig.windows.json
+++ b/src/SMAPI.Installer/assets/runtimeconfig.windows.json
@@ -1,6 +1,7 @@
 {
     "runtimeOptions": {
         "tfm": "net5.0",
+        "rollForward": "LatestMajor",
         "framework": {
             "name": "Microsoft.NETCore.App",
             "version": "5.0.0"


### PR DESCRIPTION
installer works fine with .NET 6 but it spits error due insufficient config at runtimeconfig.json file.
i added "rollForward": "LatestMajor" line to allow use newer sdk than .NET 5

i tested on archlinux with latest dotnet environment ( .NET6 ) and this solution work. probably will work fine in windows too.