### PR TITLE
Added shell shebang to MacOS Launcher code

### DIFF
--- a/src/SMAPI.Installer/assets/unix-launcher.sh
+++ b/src/SMAPI.Installer/assets/unix-launcher.sh
@@ -31,7 +31,8 @@ if [ "$(uname)" == "Darwin" ]; then
         # https://stackoverflow.com/a/29511052/262123
         if [ "$SKIP_TERMINAL" == "false" ]; then
             echo "Reopening in the Terminal app..."
-            echo "\"$0\" $@ --no-reopen-terminal" > /tmp/open-smapi-terminal.sh
+            echo '#!/bin/sh" > /tmp/open-smapi-terminal.sh
+            echo "\"$0\" $@ --no-reopen-terminal" >> /tmp/open-smapi-terminal.sh
             chmod +x /tmp/open-smapi-terminal.sh
             cat /tmp/open-smapi-terminal.sh
             open -W -a Terminal /tmp/open-smapi-terminal.sh


### PR DESCRIPTION
I use fish as my primary shell which causes errors related to the exec builtin when the system tries to open SMAPI. I assume this would also occur with other shells that aren't moelled on bash/sh as well.

Just updating the code to add a shebang to force use of /bin/sh which resolves the issue.