### PR TITLE
API proxy improvements

### DIFF
--- a/src/SMAPI/Framework/Reflection/InterfaceProxyBuilder.cs
+++ b/src/SMAPI/Framework/Reflection/InterfaceProxyBuilder.cs
@@ -133,7 +133,7 @@ namespace StardewModdingAPI.Framework.Reflection
         /// <param name="instanceField">The proxy field containing the API instance.</param>
         private void ProxyMethod(TypeBuilder proxyBuilder, MethodInfo proxy, MethodInfo target, FieldBuilder instanceField)
         {
-            MethodBuilder methodBuilder = proxyBuilder.DefineMethod(target.Name, MethodAttributes.Public | MethodAttributes.Final | MethodAttributes.Virtual);
+            MethodBuilder methodBuilder = proxyBuilder.DefineMethod(proxy.Name, MethodAttributes.Public | MethodAttributes.Final | MethodAttributes.Virtual);
 
             // set up generic arguments
             Type[] proxyGenericArguments = proxy.GetGenericArguments();

--- a/src/SMAPI/Framework/Reflection/InterfaceProxyBuilder.cs
+++ b/src/SMAPI/Framework/Reflection/InterfaceProxyBuilder.cs
@@ -143,7 +143,6 @@ namespace StardewModdingAPI.Framework.Reflection
                 genericTypeParameterBuilders[i].SetGenericParameterAttributes(proxyGenericArguments[i].GenericParameterAttributes);
 
             // set up return type
-            // TODO: keep if it's decided to use isAssignableFrom
             methodBuilder.SetReturnType(proxy.ReturnType.IsGenericMethodParameter ? genericTypeParameterBuilders[proxy.ReturnType.GenericParameterPosition] : proxy.ReturnType);
 
             // set up parameters


### PR DESCRIPTION
Example API in a supplying mod:
```cs
public interface ITestApi
{
    int NormalMethod(string a, double b, float[] c);

    int DefaultNormalMethod(double b, float[] c)
        => NormalMethod(null, b, c);
}

public class TestApi: ITestApi
{
    public int NormalMethod(string a, double b, float[] c)
        => 42;

    public int MethodWithDefaultValues(object a, int b = 5, string c = "test")
        => b * (c.Length + 1) * (a.GetHashCode() + 1);

    public R GenericMethod<A, B, C, R>(C c, A a, B b)
        => default;

    public int ParamsMethod(int a, params string[] tests)
        => 69;

    public bool OutAndRefMethod(int normalParam, out int outParam, ref int refParam)
    {
        outParam = refParam + normalParam;
        return true;
    }

    public string IsAssignableTest(object anyObj)
        => anyObj.ToString();
}
```

Example API in a consuming mod:
```cs
public interface ITestApi
{
    int NormalMethod(string a, double b, float[] c);

    int DefaultNormalMethod(double b, float[] c);

    int MethodWithDefaultValues(object a, int b = 5, string c = "test");

    R GenericMethod<A, B, C, R>(C c, A a, B b);

    int ParamsMethod(int a, params string[] tests);

    bool OutAndRefMethod(int normalParam, out int outParam, ref int refParam);

    object IsAssignableTest(string anyObj);
}
```

Example usage in a consuming mod:
```cs
var testApi = Helper.ModRegistry.GetApi<ITestApi>("SomeAuthor.SomeSupplyingMod");
int outInt;
int refInt = 3;

Monitor.Log($"NormalMethod: {testApi.NormalMethod("a", 3.14, new float[] { 2.3f, 5.7f, 11.13f })}");
Monitor.Log($"DefaultNormalMethod: {testApi.DefaultNormalMethod(3.14, new float[] { 1, 2, 3 })}");
Monitor.Log($"MethodWithDefaultValues: {testApi.MethodWithDefaultValues("asdf")}");
Monitor.Log($"GenericMethod: {testApi.GenericMethod<int, float, double, string>(3.0, 1, 2f)}");
Monitor.Log($"ParamsMethod: {testApi.ParamsMethod(10, "a", "b", "c")}");
Monitor.Log($"OutAndRefMethod: {testApi.OutAndRefMethod(2, out outInt, ref refInt)}");
Monitor.Log($"IsAssignableTest: {testApi.IsAssignableTest("testing")}");
Monitor.Log($"outInt: {outInt}");
```