### PR TITLE
Make SKIP_TERMINAL default to false if not set

### DIFF
--- a/src/SMAPI.Installer/assets/unix-launcher.sh
+++ b/src/SMAPI.Installer/assets/unix-launcher.sh
@@ -8,7 +8,7 @@ cd "$(dirname "$0")" || exit $?
 
 # change to true to skip opening a terminal
 # This isn't recommended since you won't see errors, warnings, and update alerts.
-SKIP_TERMINAL=false
+SKIP_TERMINAL=${SKIP_TERMINAL:=false}
 
 
 ##########

--- a/src/SMAPI.Installer/assets/unix-launcher.sh
+++ b/src/SMAPI.Installer/assets/unix-launcher.sh
@@ -8,7 +8,17 @@ cd "$(dirname "$0")" || exit $?
 
 # change to true to skip opening a terminal
 # This isn't recommended since you won't see errors, warnings, and update alerts.
-SKIP_TERMINAL=${SKIP_TERMINAL:=false}
+OPTS=`getopt -o St --long skip-terminal,terminal -n 'parse-options' -- "$@"`
+while true; do
+  case "$1" in
+    -S | --skip-terminal ) SKIP_TERMINAL=true; shift ;;
+    -t | --terminal ) SKIP_TERMINAL=false; shift ;;
+    -- ) shift; break ;;
+    * ) break ;;
+  esac
+done
+
+${SKIP_TERMINAL:=false}
 
 
 ##########


### PR DESCRIPTION
Makes the unix launcher script default the SKIP_TERMINAL env var to false if it's not set.
This allows users to disable the terminal without having to modify the script.
On Steam setting the following as launch arguments will skip the terminal: `SKIP_TERMINAL=true %command%`