### PR TITLE
Support for weak DLL mod dependencies

### DIFF
--- a/src/SMAPI.Toolkit.CoreInterfaces/IManifestDependency.cs
+++ b/src/SMAPI.Toolkit.CoreInterfaces/IManifestDependency.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace StardewModdingAPI
 {
     /// <summary>A mod dependency listed in a mod manifest.</summary>
@@ -14,5 +16,8 @@ namespace StardewModdingAPI
 
         /// <summary>Whether the dependency must be installed to use the mod.</summary>
         bool IsRequired { get; }
+
+        /// <summary>The names of the assemblies this dependency provides.</summary>
+        IList<string> ProvidedAssemblies { get; }
     }
 }

--- a/src/SMAPI.Toolkit/Serialization/Converters/ManifestDependencyArrayConverter.cs
+++ b/src/SMAPI.Toolkit/Serialization/Converters/ManifestDependencyArrayConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using StardewModdingAPI.Toolkit.Serialization.Models;
@@ -43,7 +44,8 @@ namespace StardewModdingAPI.Toolkit.Serialization.Converters
                 string uniqueID = obj.ValueIgnoreCase<string>(nameof(ManifestDependency.UniqueID));
                 string minVersion = obj.ValueIgnoreCase<string>(nameof(ManifestDependency.MinimumVersion));
                 bool required = obj.ValueIgnoreCase<bool?>(nameof(ManifestDependency.IsRequired)) ?? true;
-                result.Add(new ManifestDependency(uniqueID, minVersion, required));
+                IList<string> providedAssemblies = obj.ValueIgnoreCase<JArray>(nameof(ManifestDependency.ProvidedAssemblies))?.Select(a => (string)a)?.ToList();
+                result.Add(new ManifestDependency(uniqueID, minVersion, required, providedAssemblies));
             }
             return result.ToArray();
         }

--- a/src/SMAPI.Toolkit/Serialization/Models/ManifestDependency.cs
+++ b/src/SMAPI.Toolkit/Serialization/Models/ManifestDependency.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace StardewModdingAPI.Toolkit.Serialization.Models
 {
     /// <summary>A mod dependency listed in a mod manifest.</summary>
@@ -6,14 +8,17 @@ namespace StardewModdingAPI.Toolkit.Serialization.Models
         /*********
         ** Accessors
         *********/
-        /// <summary>The unique mod ID to require.</summary>
+        /// <inheritdoc/>
         public string UniqueID { get; set; }
 
-        /// <summary>The minimum required version (if any).</summary>
+        /// <inheritdoc/>
         public ISemanticVersion MinimumVersion { get; set; }
 
-        /// <summary>Whether the dependency must be installed to use the mod.</summary>
+        /// <inheritdoc/>
         public bool IsRequired { get; set; }
+
+        /// <inheritdoc/>
+        public IList<string> ProvidedAssemblies { get; set; }
 
 
         /*********
@@ -23,13 +28,17 @@ namespace StardewModdingAPI.Toolkit.Serialization.Models
         /// <param name="uniqueID">The unique mod ID to require.</param>
         /// <param name="minimumVersion">The minimum required version (if any).</param>
         /// <param name="required">Whether the dependency must be installed to use the mod.</param>
-        public ManifestDependency(string uniqueID, string minimumVersion, bool required = true)
+        /// <param name="providedAssemblies">The names of the assemblies provided by the dependency.</param>
+        public ManifestDependency(string uniqueID, string minimumVersion, bool required = true, IList<string> providedAssemblies = null)
         {
             this.UniqueID = uniqueID;
             this.MinimumVersion = !string.IsNullOrWhiteSpace(minimumVersion)
                 ? new SemanticVersion(minimumVersion)
                 : null;
             this.IsRequired = required;
+            this.ProvidedAssemblies = providedAssemblies is null
+                ? new List<string>()
+                : new List<string>(providedAssemblies);
         }
     }
 }

--- a/src/SMAPI/Framework/IModMetadata.cs
+++ b/src/SMAPI/Framework/IModMetadata.cs
@@ -130,6 +130,9 @@ namespace StardewModdingAPI.Framework
         /// <param name="includeOptional">Whether to include optional dependencies.</param>
         IEnumerable<string> GetRequiredModIds(bool includeOptional = false);
 
+        /// <summary>Get the names of the assemblies provided by the required mod with the specified ID.</summary>
+        IEnumerable<string> GetAssemblyNamesProvidedByRequiredMod(string modId);
+
         /// <summary>Whether the mod has at least one valid update key set.</summary>
         bool HasValidUpdateKeys();
 

--- a/src/SMAPI/Framework/ModLoading/AssemblyLoader.cs
+++ b/src/SMAPI/Framework/ModLoading/AssemblyLoader.cs
@@ -124,7 +124,7 @@ namespace StardewModdingAPI.Framework.ModLoading
                 // detect broken assembly reference
                 foreach (AssemblyNameReference reference in assembly.Definition.MainModule.AssemblyReferences)
                 {
-                    if (!reference.Name.StartsWith("System.") && !this.IsAssemblyLoaded(reference))
+                    if (!reference.Name.StartsWith("System.") && !this.IsAssemblyLoaded(reference) && !this.IsAssemblyProvidedByDependencies(mod, reference))
                     {
                         this.Monitor.LogOnce(loggedMessages, $"      Broken code in {assembly.File.Name}: reference to missing assembly '{reference.FullName}'.");
                         if (!assumeCompatible)
@@ -219,6 +219,19 @@ namespace StardewModdingAPI.Framework.ModLoading
         /****
         ** Assembly parsing
         ****/
+        /// <summary>Get whether a specific assembly reference is provided by the mod's dependencies.</summary>
+        /// <param name="mod">The mod for which the assembly is being loaded.</param>
+        /// <param name="reference">The assembly reference to check for.</param>
+        /// <returns>Returns whether the specific assembly reference is provided by the mod's dependencies.</returns>
+        private bool IsAssemblyProvidedByDependencies(IModMetadata mod, AssemblyNameReference reference)
+        {
+            foreach (string dependencyModId in mod.GetRequiredModIds(true))
+                foreach (string providedAssemblyName in mod.GetAssemblyNamesProvidedByRequiredMod(dependencyModId))
+                    if (providedAssemblyName == reference.Name)
+                        return true;
+            return false;
+        }
+
         /// <summary>Get a list of referenced local assemblies starting from the mod assembly, ordered from leaf to root.</summary>
         /// <param name="file">The assembly file to load.</param>
         /// <param name="visitedAssemblyNames">The assembly names that should be skipped.</param>


### PR DESCRIPTION
Currently, SMAPI will straight out disallow loading of mods with assembly references which could not be loaded. This means weak/optional dependencies on code (.dll) mods do not actually do anything and act like strong/required dependencies. This PR changes that.

A dependency can now have an additional `ProvidedAssemblies` field, with a list of assembly names that dependency provides. Any assemblies which cannot be resolved that are also listed in this way will be ignored, and the mod will be allowed to continue loading.

The mod author still has to make sure to never call any methods referencing types from those assemblies, nor declare any members referencing those types directly. Doing so will throw an exception.
Those types can be used just fine as method local variable types.
Values can still be returned and stored in properties, as long as they are upcasted to `object` (or any other type from a resolvable assembly). Then, they can be downcasted again to their respective type inside a method body.