### PR TITLE
Add command-line arguments to toggle developer mode

### DIFF
--- a/src/SMAPI/Framework/SCore.cs
+++ b/src/SMAPI/Framework/SCore.cs
@@ -168,8 +168,8 @@ namespace StardewModdingAPI.Framework
         /// <summary>Construct an instance.</summary>
         /// <param name="modsPath">The path to search for mods.</param>
         /// <param name="writeToConsole">Whether to output log messages to the console.</param>
-        /// <param name="developerModeValue">null if not modified else whether to use developer mode</param>
-        public SCore(string modsPath, bool writeToConsole, bool? developerModeValue)
+        /// <param name="developerMode">Whether to enable development features, or <c>null</c> to use the value from the settings file.</param>
+        public SCore(string modsPath, bool writeToConsole, bool? developerMode)
         {
             SCore.Instance = this;
 
@@ -184,12 +184,7 @@ namespace StardewModdingAPI.Framework
 
             // init basics
             this.Settings = JsonConvert.DeserializeObject<SConfig>(File.ReadAllText(Constants.ApiConfigPath));
-
-            // temporary overwrite DeveloperMode Setting
-            if (developerModeValue.HasValue)
-            {
-                this.Settings.DeveloperMode = developerModeValue.Value;
-            }
+            this.Settings.DeveloperMode = developerMode ?? this.Settings.DeveloperMode;
 
             if (File.Exists(Constants.ApiUserConfigPath))
                 JsonConvert.PopulateObject(File.ReadAllText(Constants.ApiUserConfigPath), this.Settings);

--- a/src/SMAPI/Framework/SCore.cs
+++ b/src/SMAPI/Framework/SCore.cs
@@ -168,7 +168,8 @@ namespace StardewModdingAPI.Framework
         /// <summary>Construct an instance.</summary>
         /// <param name="modsPath">The path to search for mods.</param>
         /// <param name="writeToConsole">Whether to output log messages to the console.</param>
-        public SCore(string modsPath, bool writeToConsole)
+        /// <param name="developerModeValue">null if not modified else whether to use developer mode</param>
+        public SCore(string modsPath, bool writeToConsole, bool? developerModeValue)
         {
             SCore.Instance = this;
 
@@ -183,6 +184,13 @@ namespace StardewModdingAPI.Framework
 
             // init basics
             this.Settings = JsonConvert.DeserializeObject<SConfig>(File.ReadAllText(Constants.ApiConfigPath));
+
+            // temporary overwrite DeveloperMode Setting
+            if (developerModeValue.HasValue)
+            {
+                this.Settings.DeveloperMode = developerModeValue.Value;
+            }
+
             if (File.Exists(Constants.ApiUserConfigPath))
                 JsonConvert.PopulateObject(File.ReadAllText(Constants.ApiUserConfigPath), this.Settings);
 

--- a/src/SMAPI/Framework/SCore.cs
+++ b/src/SMAPI/Framework/SCore.cs
@@ -184,10 +184,9 @@ namespace StardewModdingAPI.Framework
 
             // init basics
             this.Settings = JsonConvert.DeserializeObject<SConfig>(File.ReadAllText(Constants.ApiConfigPath));
-            this.Settings.DeveloperMode = developerMode ?? this.Settings.DeveloperMode;
-
             if (File.Exists(Constants.ApiUserConfigPath))
                 JsonConvert.PopulateObject(File.ReadAllText(Constants.ApiUserConfigPath), this.Settings);
+            this.Settings.DeveloperMode = developerMode ?? this.Settings.DeveloperMode;
 
             this.LogManager = new LogManager(logPath: logPath, colorConfig: this.Settings.ConsoleColors, writeToConsole: writeToConsole, isVerbose: this.Settings.VerboseLogging, isDeveloperMode: this.Settings.DeveloperMode, getScreenIdForLog: this.GetScreenIdForLog);
             this.CommandManager = new CommandManager(this.Monitor);

--- a/src/SMAPI/Program.cs
+++ b/src/SMAPI/Program.cs
@@ -179,14 +179,29 @@ namespace StardewModdingAPI
             bool writeToConsole = !args.Contains("--no-terminal") && Environment.GetEnvironmentVariable("SMAPI_NO_TERMINAL") == null;
 
             // get mods path
+            bool? developerModeValue = null;
             string modsPath;
             {
                 string rawModsPath = null;
 
-                // get from command line args
+                // get mods path from command line args
                 int pathIndex = Array.LastIndexOf(args, "--mods-path") + 1;
                 if (pathIndex >= 1 && args.Length >= pathIndex)
                     rawModsPath = args[pathIndex];
+
+                // get developer mode from command line args
+                int developerModeValueIndex = Array.LastIndexOf(args, "--developer-mode") + 1;
+                if (developerModeValueIndex >= 1 && args.Length >= developerModeValueIndex)
+                {
+                    if (args[developerModeValueIndex].ToLower().Equals("true"))
+                    {
+                        developerModeValue = true;
+                    }
+                    else if (args[developerModeValueIndex].ToLower().Equals("false"))
+                    {
+                        developerModeValue = false;
+                    }
+                }
 
                 // get from environment variables
                 if (string.IsNullOrWhiteSpace(rawModsPath))
@@ -199,7 +214,7 @@ namespace StardewModdingAPI
             }
 
             // load SMAPI
-            using SCore core = new SCore(modsPath, writeToConsole);
+            using SCore core = new SCore(modsPath, writeToConsole, developerModeValue);
             core.RunInteractively();
         }
 

--- a/src/SMAPI/Program.cs
+++ b/src/SMAPI/Program.cs
@@ -179,7 +179,7 @@ namespace StardewModdingAPI
             bool writeToConsole = !args.Contains("--no-terminal") && Environment.GetEnvironmentVariable("SMAPI_NO_TERMINAL") == null;
 
             // get mods path
-            bool? developerModeValue = null;
+            bool? developerMode = null;
             string modsPath;
             {
                 string rawModsPath = null;
@@ -190,31 +190,23 @@ namespace StardewModdingAPI
                     rawModsPath = args[pathIndex];
 
                 // get developer mode from command line args
-                int developerModeValueIndex = Array.LastIndexOf(args, "--developer-mode") + 1;
-                if (developerModeValueIndex >= 1 && args.Length >= developerModeValueIndex)
-                {
-                    if (args[developerModeValueIndex].ToLower().Equals("true"))
-                    {
-                        developerModeValue = true;
-                    }
-                    else if (args[developerModeValueIndex].ToLower().Equals("false"))
-                    {
-                        developerModeValue = false;
-                    }
-                }
+                if (args.Contains("--developer-mode"))
+                    developerMode = true;
+                if (args.Contains("--developer-mode-off"))
+                    developerMode = false;
 
                 // get from environment variables
                 if (string.IsNullOrWhiteSpace(rawModsPath))
                     rawModsPath = Environment.GetEnvironmentVariable("SMAPI_MODS_PATH");
 
-                // normalise
+                // normalize
                 modsPath = !string.IsNullOrWhiteSpace(rawModsPath)
                     ? Path.Combine(Constants.GamePath, rawModsPath)
                     : Constants.DefaultModsPath;
             }
 
             // load SMAPI
-            using SCore core = new SCore(modsPath, writeToConsole, developerModeValue);
+            using SCore core = new SCore(modsPath, writeToConsole, developerMode);
             core.RunInteractively();
         }
 


### PR DESCRIPTION
Minimal changes required to enable/disable developer mode  via command line argument. This commit does not include any error handling for invalid values how ever they will be ignored and not crash the game.

However a better solution would be to use a library like Mono.Options to parse command arguments and include error handling. For example at the moment `--mods-path` crashes the game in case the mod path, cannot be created.
It could also add well known linux commands like `-V` `-h`. easier.