### PR TITLE
Improve log parser

### DIFF
--- a/src/SMAPI.Web/Controllers/LogParserController.cs
+++ b/src/SMAPI.Web/Controllers/LogParserController.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 using System.Linq;
 using System.Text;
@@ -47,7 +45,7 @@ namespace StardewModdingAPI.Web.Controllers
         [HttpGet]
         [Route("log")]
         [Route("log/{id}")]
-        public async Task<ActionResult> Index(string id = null, LogViewFormat format = LogViewFormat.Default, bool renew = false)
+        public async Task<ActionResult> Index(string? id = null, LogViewFormat format = LogViewFormat.Default, bool renew = false)
         {
             // fresh page
             if (string.IsNullOrWhiteSpace(id))
@@ -89,7 +87,7 @@ namespace StardewModdingAPI.Web.Controllers
         public async Task<ActionResult> PostAsync()
         {
             // get raw log text
-            string input = this.Request.Form["input"].FirstOrDefault();
+            string? input = this.Request.Form["input"].FirstOrDefault();
             if (string.IsNullOrWhiteSpace(input))
                 return this.View("Index", this.GetModel(null, uploadError: "The log file seems to be empty."));
 
@@ -111,7 +109,7 @@ namespace StardewModdingAPI.Web.Controllers
         /// <param name="expiry">When the uploaded file will no longer be available.</param>
         /// <param name="uploadWarning">A non-blocking warning while uploading the log.</param>
         /// <param name="uploadError">An error which occurred while uploading the log.</param>
-        private LogParserModel GetModel(string pasteID, DateTime? expiry = null, string uploadWarning = null, string uploadError = null)
+        private LogParserModel GetModel(string? pasteID, DateTime? expiry = null, string? uploadWarning = null, string? uploadError = null)
         {
             Platform? platform = this.DetectClientPlatform();
 

--- a/src/SMAPI.Web/Framework/LogParsing/LogMessageBuilder.cs
+++ b/src/SMAPI.Web/Framework/LogParsing/LogMessageBuilder.cs
@@ -1,6 +1,5 @@
-#nullable disable
-
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using StardewModdingAPI.Web.Framework.LogParsing.Models;
 
@@ -13,7 +12,7 @@ namespace StardewModdingAPI.Web.Framework.LogParsing
         ** Fields
         *********/
         /// <summary>The local time when the next log was posted.</summary>
-        public string Time { get; set; }
+        public string? Time { get; set; }
 
         /// <summary>The log level for the next log message.</summary>
         public LogLevel Level { get; set; }
@@ -22,7 +21,7 @@ namespace StardewModdingAPI.Web.Framework.LogParsing
         public int ScreenId { get; set; }
 
         /// <summary>The mod name for the next log message.</summary>
-        public string Mod { get; set; }
+        public string? Mod { get; set; }
 
         /// <summary>The text for the next log message.</summary>
         private readonly StringBuilder Text = new();
@@ -32,6 +31,7 @@ namespace StardewModdingAPI.Web.Framework.LogParsing
         ** Accessors
         *********/
         /// <summary>Whether the next log message has been started.</summary>
+        [MemberNotNullWhen(true, nameof(LogMessageBuilder.Time), nameof(LogMessageBuilder.Mod))]
         public bool Started { get; private set; }
 
 
@@ -72,19 +72,18 @@ namespace StardewModdingAPI.Web.Framework.LogParsing
         }
 
         /// <summary>Get a log message for the accumulated values.</summary>
-        public LogMessage Build()
+        public LogMessage? Build()
         {
             if (!this.Started)
                 return null;
 
-            return new LogMessage
-            {
-                Time = this.Time,
-                Level = this.Level,
-                ScreenId = this.ScreenId,
-                Mod = this.Mod,
-                Text = this.Text.ToString()
-            };
+            return new LogMessage(
+                time: this.Time,
+                level: this.Level,
+                screenId: this.ScreenId,
+                mod: this.Mod,
+                text: this.Text.ToString()
+            );
         }
 
         /// <summary>Reset to start a new log message.</summary>

--- a/src/SMAPI.Web/Framework/LogParsing/LogParseException.cs
+++ b/src/SMAPI.Web/Framework/LogParsing/LogParseException.cs
@@ -1,5 +1,3 @@
-#nullable disable
-
 using System;
 
 namespace StardewModdingAPI.Web.Framework.LogParsing

--- a/src/SMAPI.Web/Framework/LogParsing/Models/LogMessage.cs
+++ b/src/SMAPI.Web/Framework/LogParsing/Models/LogMessage.cs
@@ -1,4 +1,4 @@
-#nullable disable
+using System.Diagnostics.CodeAnalysis;
 
 namespace StardewModdingAPI.Web.Framework.LogParsing.Models
 {
@@ -9,19 +9,19 @@ namespace StardewModdingAPI.Web.Framework.LogParsing.Models
         ** Accessors
         *********/
         /// <summary>The local time when the log was posted.</summary>
-        public string Time { get; set; }
+        public string Time { get; }
 
         /// <summary>The log level.</summary>
-        public LogLevel Level { get; set; }
+        public LogLevel Level { get; }
 
         /// <summary>The screen ID in split-screen mode.</summary>
-        public int ScreenId { get; set; }
+        public int ScreenId { get; }
 
         /// <summary>The mod name.</summary>
-        public string Mod { get; set; }
+        public string Mod { get; }
 
         /// <summary>The log text.</summary>
-        public string Text { get; set; }
+        public string Text { get; }
 
         /// <summary>The number of times this message was repeated consecutively.</summary>
         public int Repeated { get; set; }
@@ -30,6 +30,32 @@ namespace StardewModdingAPI.Web.Framework.LogParsing.Models
         public LogSection? Section { get; set; }
 
         /// <summary>Whether this message is the first one of its section.</summary>
+        [MemberNotNullWhen(true, nameof(LogMessage.Section))]
         public bool IsStartOfSection { get; set; }
+
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Construct an instance/</summary>
+        /// <param name="time">The local time when the log was posted.</param>
+        /// <param name="level">The log level.</param>
+        /// <param name="screenId">The screen ID in split-screen mode.</param>
+        /// <param name="mod">The mod name.</param>
+        /// <param name="text">The log text.</param>
+        /// <param name="repeated">The number of times this message was repeated consecutively.</param>
+        /// <param name="section">The section that this log message belongs to.</param>
+        /// <param name="isStartOfSection">Whether this message is the first one of its section.</param>
+        public LogMessage(string time, LogLevel level, int screenId, string mod, string text, int repeated = 0, LogSection? section = null, bool isStartOfSection = false)
+        {
+            this.Time = time;
+            this.Level = level;
+            this.ScreenId = screenId;
+            this.Mod = mod;
+            this.Text = text;
+            this.Repeated = repeated;
+            this.Section = section;
+            this.IsStartOfSection = isStartOfSection;
+        }
     }
 }

--- a/src/SMAPI.Web/Framework/LogParsing/Models/LogModInfo.cs
+++ b/src/SMAPI.Web/Framework/LogParsing/Models/LogModInfo.cs
@@ -1,4 +1,4 @@
-#nullable disable
+using System.Diagnostics.CodeAnalysis;
 
 namespace StardewModdingAPI.Web.Framework.LogParsing.Models
 {
@@ -9,36 +9,81 @@ namespace StardewModdingAPI.Web.Framework.LogParsing.Models
         ** Accessors
         *********/
         /// <summary>The mod name.</summary>
-        public string Name { get; set; }
+        public string Name { get; }
 
         /// <summary>The mod author.</summary>
-        public string Author { get; set; }
-
-        /// <summary>The update version.</summary>
-        public string UpdateVersion { get; set; }
-
-        /// <summary>The update link.</summary>
-        public string UpdateLink { get; set; }
+        public string Author { get; }
 
         /// <summary>The mod version.</summary>
-        public string Version { get; set; }
+        public string Version { get; private set; }
 
         /// <summary>The mod description.</summary>
-        public string Description { get; set; }
+        public string Description { get; }
+
+        /// <summary>The update version.</summary>
+        public string? UpdateVersion { get; private set; }
+
+        /// <summary>The update link.</summary>
+        public string? UpdateLink { get; private set; }
 
         /// <summary>The name of the mod for which this is a content pack (if applicable).</summary>
-        public string ContentPackFor { get; set; }
+        public string? ContentPackFor { get; }
 
         /// <summary>The number of errors logged by this mod.</summary>
         public int Errors { get; set; }
 
         /// <summary>Whether the mod was loaded into the game.</summary>
-        public bool Loaded { get; set; }
+        public bool Loaded { get; }
 
         /// <summary>Whether the mod has an update available.</summary>
+        [MemberNotNullWhen(true, nameof(LogModInfo.UpdateVersion), nameof(LogModInfo.UpdateLink))]
         public bool HasUpdate => this.UpdateVersion != null && this.Version != this.UpdateVersion;
 
         /// <summary>Whether the mod is a content pack for another mod.</summary>
+        [MemberNotNullWhen(true, nameof(LogModInfo.ContentPackFor))]
         public bool IsContentPack => !string.IsNullOrWhiteSpace(this.ContentPackFor);
+
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Construct an instance.</summary>
+        /// <param name="name">The mod name.</param>
+        /// <param name="author">The mod author.</param>
+        /// <param name="version">The mod version.</param>
+        /// <param name="description">The mod description.</param>
+        /// <param name="updateVersion">The update version.</param>
+        /// <param name="updateLink">The update link.</param>
+        /// <param name="contentPackFor">The name of the mod for which this is a content pack (if applicable).</param>
+        /// <param name="errors">The number of errors logged by this mod.</param>
+        /// <param name="loaded">Whether the mod was loaded into the game.</param>
+        public LogModInfo(string name, string author, string version, string description, string? updateVersion = null, string? updateLink = null, string? contentPackFor = null, int errors = 0, bool loaded = true)
+        {
+            this.Name = name;
+            this.Author = author;
+            this.Version = version;
+            this.Description = description;
+            this.UpdateVersion = updateVersion;
+            this.UpdateLink = updateLink;
+            this.ContentPackFor = contentPackFor;
+            this.Errors = errors;
+            this.Loaded = loaded;
+        }
+
+        /// <summary>Add an update alert for this mod.</summary>
+        /// <param name="updateVersion">The update version.</param>
+        /// <param name="updateLink">The update link.</param>
+        public void SetUpdate(string updateVersion, string updateLink)
+        {
+            this.UpdateVersion = updateVersion;
+            this.UpdateLink = updateLink;
+        }
+
+        /// <summary>Override the version number, for cases like SMAPI itself where the version is only known later during parsing.</summary>
+        /// <param name="version">The new mod version.</param>
+        public void OverrideVersion(string version)
+        {
+            this.Version = version;
+        }
     }
 }

--- a/src/SMAPI.Web/Framework/LogParsing/Models/ParsedLog.cs
+++ b/src/SMAPI.Web/Framework/LogParsing/Models/ParsedLog.cs
@@ -1,6 +1,5 @@
-#nullable disable
-
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace StardewModdingAPI.Web.Framework.LogParsing.Models
 {
@@ -14,31 +13,32 @@ namespace StardewModdingAPI.Web.Framework.LogParsing.Models
         ** Metadata
         ****/
         /// <summary>Whether the log file was successfully parsed.</summary>
+        [MemberNotNullWhen(true, nameof(ParsedLog.RawText))]
         public bool IsValid { get; set; }
 
         /// <summary>An error message indicating why the log file is invalid.</summary>
-        public string Error { get; set; }
+        public string? Error { get; set; }
 
         /// <summary>The raw log text.</summary>
-        public string RawText { get; set; }
+        public string? RawText { get; set; }
 
         /****
         ** Log data
         ****/
         /// <summary>The SMAPI version.</summary>
-        public string ApiVersion { get; set; }
+        public string? ApiVersion { get; set; }
 
         /// <summary>The game version.</summary>
-        public string GameVersion { get; set; }
+        public string? GameVersion { get; set; }
 
         /// <summary>The player's operating system.</summary>
-        public string OperatingSystem { get; set; }
+        public string? OperatingSystem { get; set; }
 
         /// <summary>The game install path.</summary>
-        public string GamePath { get; set; }
+        public string? GamePath { get; set; }
 
         /// <summary>The mod folder path.</summary>
-        public string ModPath { get; set; }
+        public string? ModPath { get; set; }
 
         /// <summary>The ISO 8601 timestamp when the log was started.</summary>
         public DateTimeOffset Timestamp { get; set; }
@@ -47,6 +47,6 @@ namespace StardewModdingAPI.Web.Framework.LogParsing.Models
         public LogModInfo[] Mods { get; set; } = Array.Empty<LogModInfo>();
 
         /// <summary>The log messages.</summary>
-        public LogMessage[] Messages { get; set; }
+        public LogMessage[] Messages { get; set; } = Array.Empty<LogMessage>();
     }
 }

--- a/src/SMAPI.Web/Views/LogParser/Index.cshtml
+++ b/src/SMAPI.Web/Views/LogParser/Index.cshtml
@@ -42,27 +42,40 @@
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1" crossorigin="anonymous"></script>
     <script src="~/Content/js/file-upload.js"></script>
     <script src="~/Content/js/log-parser.js"></script>
+
+    <script id="serializedData" type="application/json">
+        @if (!Model.ShowRaw)
+        {
+            <text>
+                {
+                    "messages": @this.ForJson(log?.Messages),
+                    "sections": @this.ForJson(logSections),
+                    "logLevels": @this.ForJson(logLevels),
+                    "modSlugs": @this.ForJson(log?.Mods.DistinctBy(p => p.Name).Select(p => new {p.Name, Slug = Model.GetSlug(p.Name)}).Where(p => p.Name != p.Slug).ToDictionary(p => p.Name, p => p.Slug)),
+                    "screenIds": @this.ForJson(screenIds)
+                }
+            </text>
+        }
+        else
+        {
+            <text>
+                {
+                    "messages": [],
+                    "sections": {},
+                    "logLevels": {},
+                    "modSlugs": {},
+                    "screenIds": []
+                }
+            </text>
+        }
+    </script>
+    
     <script>
         $(function() {
             smapi.logParser(
                 {
                     logStarted: new Date(@this.ForJson(log?.Timestamp)),
-                    @if (!Model.ShowRaw)
-                    {
-                        <text>
-                            data: {
-                                messages: @this.ForJson(log?.Messages),
-                                sections: @this.ForJson(logSections),
-                                logLevels: @this.ForJson(logLevels),
-                                modSlugs: @this.ForJson(log?.Mods.DistinctBy(p => p.Name).Select(p => new { p.Name, Slug = Model.GetSlug(p.Name) }).Where(p => p.Name != p.Slug).ToDictionary(p => p.Name, p => p.Slug)),
-                                screenIds: @this.ForJson(screenIds)
-                            },
-                        </text>
-                    }
-                    else
-                    {
-                        <text>data: null,</text>
-                    }
+                    dataElement: "script#serializedData",
                     showPopup: @this.ForJson(log == null),
                     showMods: @this.ForJson(log?.Mods.Select(p => Model.GetSlug(p.Name)).Distinct().ToDictionary(slug => slug, _ => true)),
                     showSections: @this.ForJson(Enum.GetNames(typeof(LogSection)).ToDictionary(section => section, _ => false)),

--- a/src/SMAPI.Web/Views/LogParser/Index.cshtml
+++ b/src/SMAPI.Web/Views/LogParser/Index.cshtml
@@ -44,13 +44,6 @@
     <link rel="stylesheet" href="~/Content/css/log-parser.css" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tabbyjs@12.0.3/dist/css/tabby-ui-vertical.min.css" />
 
-    @if (!Model.ShowRaw)
-    {
-    <script id="logSections" type="application/json">@this.ForJson(logSections)</script>
-    <script id="logLevels" type="application/json">@this.ForJson(logLevels)</script>
-    <script id="parsedMessages" type="application/json">@this.ForJson(log?.Messages)</script>
-    <script id="modSlugs" type="application/json">@this.ForJson(log?.Mods?.DistinctBy(m => m.Name).ToDictionary(m => m.Name, m => Model.GetSlug(m.Name)))</script>
-    }
     <script src="https://cdn.jsdelivr.net/npm/tabbyjs@12.0.3" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1" crossorigin="anonymous"></script>
@@ -58,15 +51,33 @@
     <script src="~/Content/js/log-parser.js"></script>
     <script>
         $(function() {
-            smapi.logParser({
-                logStarted: new Date(@this.ForJson(log?.Timestamp)),
-                showPopup: @this.ForJson(log == null),
-                showMods: @this.ForJson(log?.Mods?.Select(p => Model.GetSlug(p.Name)).Distinct().ToDictionary(slug => slug, _ => true)),
-                showSections: @this.ForJson(Enum.GetNames(typeof(LogSection)).ToDictionary(section => section, _ => false)),
-                showLevels: @this.ForJson(defaultFilters),
-                enableFilters: @this.ForJson(!Model.ShowRaw),
-                screenIds: @this.ForJson(screenIds)
-            }, '@this.Url.PlainAction("Index", "LogParser", values: null)');
+            smapi.logParser(
+                {
+                    logStarted: new Date(@this.ForJson(log?.Timestamp)),
+                    @if (!Model.ShowRaw)
+                    {
+                        <text>
+                            data: {
+                                messages: @this.ForJson(log?.Messages),
+                                sections: @this.ForJson(logSections),
+                                logLevels: @this.ForJson(logLevels),
+                                modSlugs: @this.ForJson(log?.Mods?.DistinctBy(p => p.Name).Select(p => new { p.Name, Slug = Model.GetSlug(p.Name) }).Where(p => p.Name != p.Slug).ToDictionary(p => p.Name, p => p.Slug)),
+                                screenIds: @this.ForJson(screenIds)
+                            },
+                        </text>
+                    }
+                    else
+                    {
+                        <text>data: null,</text>
+                    }
+                    showPopup: @this.ForJson(log == null),
+                    showMods: @this.ForJson(log?.Mods?.Select(p => Model.GetSlug(p.Name)).Distinct().ToDictionary(slug => slug, _ => true)),
+                    showSections: @this.ForJson(Enum.GetNames(typeof(LogSection)).ToDictionary(section => section, _ => false)),
+                    showLevels: @this.ForJson(defaultFilters),
+                    enableFilters: @this.ForJson(!Model.ShowRaw)
+                },
+                "@this.Url.PlainAction("Index", "LogParser", values: null)"
+            );
 
             new Tabby('[data-tabs]');
         });

--- a/src/SMAPI.Web/Views/LogParser/Index.cshtml
+++ b/src/SMAPI.Web/Views/LogParser/Index.cshtml
@@ -16,18 +16,15 @@
 
     IDictionary<string, LogModInfo[]> contentPacks = Model.GetContentPacksByMod();
     IDictionary<string, bool> defaultFilters = Enum
-        .GetValues(typeof(LogLevel))
-        .Cast<LogLevel>()
+        .GetValues<LogLevel>()
         .ToDictionary(level => level.ToString().ToLower(), level => level != LogLevel.Trace);
 
     IDictionary<int, string> logLevels = Enum
-        .GetValues(typeof(LogLevel))
-        .Cast<LogLevel>()
+        .GetValues<LogLevel>()
         .ToDictionary(level => (int)level, level => level.ToString().ToLower());
 
     IDictionary<int, string> logSections = Enum
-        .GetValues(typeof(LogSection))
-        .Cast<LogSection>()
+        .GetValues<LogSection>()
         .ToDictionary(section => (int)section, section => section.ToString());
 
     string curPageUrl = this.Url.PlainAction("Index", "LogParser", new { id = Model.PasteID }, absoluteUrl: true);

--- a/src/SMAPI.Web/Views/LogParser/Index.cshtml
+++ b/src/SMAPI.Web/Views/LogParser/Index.cshtml
@@ -1,7 +1,3 @@
-@{
-    #nullable disable
-}
-
 @using Humanizer
 @using StardewModdingAPI.Toolkit.Utilities
 @using StardewModdingAPI.Web.Framework
@@ -12,7 +8,7 @@
 @{
     ViewData["Title"] = "SMAPI log parser";
 
-    ParsedLog log = Model!.ParsedLog;
+    ParsedLog? log = Model!.ParsedLog;
 
     IDictionary<string, LogModInfo[]> contentPacks = Model.GetContentPacksByMod();
     IDictionary<string, bool> defaultFilters = Enum
@@ -29,7 +25,7 @@
 
     string curPageUrl = this.Url.PlainAction("Index", "LogParser", new { id = Model.PasteID }, absoluteUrl: true);
 
-    ISet<int> screenIds = new HashSet<int>(log?.Messages?.Select(p => p.ScreenId) ?? Array.Empty<int>());
+    ISet<int> screenIds = new HashSet<int>(log?.Messages.Select(p => p.ScreenId) ?? Array.Empty<int>());
 }
 
 @section Head {
@@ -58,7 +54,7 @@
                                 messages: @this.ForJson(log?.Messages),
                                 sections: @this.ForJson(logSections),
                                 logLevels: @this.ForJson(logLevels),
-                                modSlugs: @this.ForJson(log?.Mods?.DistinctBy(p => p.Name).Select(p => new { p.Name, Slug = Model.GetSlug(p.Name) }).Where(p => p.Name != p.Slug).ToDictionary(p => p.Name, p => p.Slug)),
+                                modSlugs: @this.ForJson(log?.Mods.DistinctBy(p => p.Name).Select(p => new { p.Name, Slug = Model.GetSlug(p.Name) }).Where(p => p.Name != p.Slug).ToDictionary(p => p.Name, p => p.Slug)),
                                 screenIds: @this.ForJson(screenIds)
                             },
                         </text>
@@ -68,7 +64,7 @@
                         <text>data: null,</text>
                     }
                     showPopup: @this.ForJson(log == null),
-                    showMods: @this.ForJson(log?.Mods?.Select(p => Model.GetSlug(p.Name)).Distinct().ToDictionary(slug => slug, _ => true)),
+                    showMods: @this.ForJson(log?.Mods.Select(p => Model.GetSlug(p.Name)).Distinct().ToDictionary(slug => slug, _ => true)),
                     showSections: @this.ForJson(Enum.GetNames(typeof(LogSection)).ToDictionary(section => section, _ => false)),
                     showLevels: @this.ForJson(defaultFilters),
                     enableFilters: @this.ForJson(!Model.ShowRaw)
@@ -76,7 +72,7 @@
                 "@this.Url.PlainAction("Index", "LogParser", values: null)"
             );
 
-            new Tabby('[data-tabs]');
+            new Tabby("[data-tabs]");
         });
     </script>
 }
@@ -217,12 +213,12 @@ else if (log?.IsValid == true)
                     Consider updating these mods to fix problems:
 
                     <table id="updates" class="table">
-                        @foreach (LogModInfo mod in log.Mods.Where(mod => (mod.HasUpdate && !mod.IsContentPack) || (contentPacks.TryGetValue(mod.Name, out LogModInfo[] contentPackList) && contentPackList.Any(pack => pack.HasUpdate))))
+                        @foreach (LogModInfo mod in log.Mods.Where(mod => (mod.HasUpdate && !mod.IsContentPack) || (contentPacks.TryGetValue(mod.Name, out LogModInfo[]? contentPackList) && contentPackList.Any(pack => pack.HasUpdate))))
                         {
                             <tr class="mod-entry">
                                 <td>
                                     <strong class=@(!mod.HasUpdate ? "hidden" : "")>@mod.Name</strong>
-                                    @if (contentPacks != null && contentPacks.TryGetValue(mod.Name, out LogModInfo[] contentPackList))
+                                    @if (contentPacks != null && contentPacks.TryGetValue(mod.Name, out LogModInfo[]? contentPackList))
                                     {
                                         <div class="content-packs">
                                             @foreach (LogModInfo contentPack in contentPackList.Where(pack => pack.HasUpdate))
@@ -305,8 +301,7 @@ else if (log?.IsValid == true)
             </caption>
             @foreach (var mod in log.Mods.Where(p => p.Loaded && !p.IsContentPack))
             {
-                LogModInfo[]? contentPackList;
-                if (contentPacks == null || !contentPacks.TryGetValue(mod.Name, out contentPackList))
+                if (contentPacks == null || !contentPacks.TryGetValue(mod.Name, out LogModInfo[]? contentPackList))
                     contentPackList = null;
 
                 <tr v-on:click="toggleMod('@Model.GetSlug(mod.Name)')" class="mod-entry" v-bind:class="{ hidden: !showMods['@Model.GetSlug(mod.Name)'] }">

--- a/src/SMAPI.Web/Views/LogParser/Index.cshtml
+++ b/src/SMAPI.Web/Views/LogParser/Index.cshtml
@@ -68,8 +68,7 @@
                     showSections: @this.ForJson(Enum.GetNames(typeof(LogSection)).ToDictionary(section => section, _ => false)),
                     showLevels: @this.ForJson(defaultFilters),
                     enableFilters: @this.ForJson(!Model.ShowRaw)
-                },
-                "@this.Url.PlainAction("Index", "LogParser", values: null)"
+                }
             );
 
             new Tabby("[data-tabs]");
@@ -296,7 +295,7 @@ else if (log?.IsValid == true)
                     <span class="notice txt"><i>click any mod to filter</i></span>
                     <span class="notice btn txt" v-on:click="showAllMods" v-bind:class="{ invisible: !anyModsHidden }">show all</span>
                     <span class="notice btn txt" v-on:click="hideAllMods" v-bind:class="{ invisible: !anyModsShown || !anyModsHidden }">hide all</span>
-                    <span class="notice btn txt" v-on:click="toggleContentPacks">toggle content packs</span>
+                    <span class="notice btn txt" v-on:click="toggleContentPacks">toggle content packs in list</span>
                 }
             </caption>
             @foreach (var mod in log.Mods.Where(p => p.Loaded && !p.IsContentPack))
@@ -316,7 +315,7 @@ else if (log?.IsValid == true)
                                     <text>+ @contentPack.Name @contentPack.Version</text><br />
                                 }
                             </div>
-                            <span v-else class="content-packs--short"> (+ @contentPackList.Length Content Packs)</span>
+                            <span v-else class="content-packs-collapsed"> (+ @contentPackList.Length content packs)</span>
                         }
                     </td>
                     <td>
@@ -365,14 +364,14 @@ else if (log?.IsValid == true)
                         <div class="filter-text">
                             <input
                                 type="text"
-                                v-bind:class="{ active: filterText && filterText != '' }"
+                                v-bind:class="{ active: !!filterText }"
                                 v-on:input="updateFilterText"
-                                placeholder="filter..."
+                                placeholder="search to filter log..."
                             />
-                            <span role="button" v-bind:class="{ active: filterUseRegex }" v-on:click="toggleFilterUseRegex" title="Use Regular Expression">.*</span>
-                            <span role="button" v-bind:class="{ active: !filterInsensitive }" v-on:click="toggleFilterInsensitive" title="Match Case">aA</span>
-                            <span role="button" v-bind:class="{ active: filterUseWord, 'whole-word': true }" v-on:click="toggleFilterWord" title="Match Whole Word"><i>Ab</i></span>
-                            <span role="button" v-bind:class="{ active: shouldHighlight }" v-on:click="toggleHighlight" title="Highlight Matches">HL</span>
+                            <span role="button" v-bind:class="{ active: filterUseRegex }" v-on:click="toggleFilterUseRegex" title="Use regular expression syntax.">.*</span>
+                            <span role="button" v-bind:class="{ active: !filterInsensitive }" v-on:click="toggleFilterInsensitive" title="Match exact capitalization only.">aA</span>
+                            <span role="button" v-bind:class="{ active: filterUseWord, 'whole-word': true }" v-on:click="toggleFilterWord" title="Match whole word only."><i>“ ”</i></span>
+                            <span role="button" v-bind:class="{ active: shouldHighlight }" v-on:click="toggleHighlight" title="Highlight matches in the log text.">HL</span>
                         </div>
                         <filter-stats
                             v-bind:start="start"
@@ -393,9 +392,7 @@ else if (log?.IsValid == true)
 
             <noscript>
                 <div>
-                    This website uses JavaScript to display a filterable table. To view this log, please either
-                    <a href="@this.Url.PlainAction("Index", "LogParser", new { id = Model.PasteID, format = LogViewFormat.RawView })">view the raw log</a>
-                    or enable JavaScript.
+                    This website uses JavaScript to display a filterable table. To view this log, please enable JavaScript or <a href="@this.Url.PlainAction("Index", "LogParser", new { id = Model.PasteID, format = LogViewFormat.RawView })">view the raw log</a>.
                 </div>
                 <br/>
             </noscript>

--- a/src/SMAPI.Web/Views/LogParser/Index.cshtml
+++ b/src/SMAPI.Web/Views/LogParser/Index.cshtml
@@ -404,7 +404,6 @@ else if (log?.IsValid == true)
                     v-bind:showScreenId="showScreenId"
                     v-bind:message="msg"
                     v-bind:highlight="shouldHighlight"
-                    v-bind:sectionExpanded="msg.SectionName && visibleSections.includes(msg.SectionName)"
                 />
             </log-table>
         }

--- a/src/SMAPI.Web/Views/LogParser/Index.cshtml
+++ b/src/SMAPI.Web/Views/LogParser/Index.cshtml
@@ -20,6 +20,16 @@
         .Cast<LogLevel>()
         .ToDictionary(level => level.ToString().ToLower(), level => level != LogLevel.Trace);
 
+    IDictionary<int, string> logLevels = Enum
+        .GetValues(typeof(LogLevel))
+        .Cast<LogLevel>()
+        .ToDictionary(level => (int)level, level => level.ToString().ToLower());
+
+    IDictionary<int, string> logSections = Enum
+        .GetValues(typeof(LogSection))
+        .Cast<LogSection>()
+        .ToDictionary(section => (int)section, section => section.ToString());
+
     string curPageUrl = this.Url.PlainAction("Index", "LogParser", new { id = Model.PasteID }, absoluteUrl: true);
 
     ISet<int> screenIds = new HashSet<int>(log?.Messages?.Select(p => p.ScreenId) ?? Array.Empty<int>());
@@ -34,8 +44,15 @@
     <link rel="stylesheet" href="~/Content/css/log-parser.css" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tabbyjs@12.0.3/dist/css/tabby-ui-vertical.min.css" />
 
+    @if (!Model.ShowRaw)
+    {
+    <script id="logSections" type="application/json">@this.ForJson(logSections)</script>
+    <script id="logLevels" type="application/json">@this.ForJson(logLevels)</script>
+    <script id="parsedMessages" type="application/json">@this.ForJson(log?.Messages)</script>
+    <script id="modSlugs" type="application/json">@this.ForJson(log?.Mods?.DistinctBy(m => m.Name).ToDictionary(m => m.Name, m => Model.GetSlug(m.Name)))</script>
+    }
     <script src="https://cdn.jsdelivr.net/npm/tabbyjs@12.0.3" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.11" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1" crossorigin="anonymous"></script>
     <script src="~/Content/js/file-upload.js"></script>
     <script src="~/Content/js/log-parser.js"></script>
@@ -275,29 +292,35 @@ else if (log?.IsValid == true)
                     <span class="notice txt"><i>click any mod to filter</i></span>
                     <span class="notice btn txt" v-on:click="showAllMods" v-bind:class="{ invisible: !anyModsHidden }">show all</span>
                     <span class="notice btn txt" v-on:click="hideAllMods" v-bind:class="{ invisible: !anyModsShown || !anyModsHidden }">hide all</span>
+                    <span class="notice btn txt" v-on:click="toggleContentPacks">toggle content packs</span>
                 }
             </caption>
             @foreach (var mod in log.Mods.Where(p => p.Loaded && !p.IsContentPack))
             {
+                LogModInfo[]? contentPackList;
+                if (contentPacks == null || !contentPacks.TryGetValue(mod.Name, out contentPackList))
+                    contentPackList = null;
+
                 <tr v-on:click="toggleMod('@Model.GetSlug(mod.Name)')" class="mod-entry" v-bind:class="{ hidden: !showMods['@Model.GetSlug(mod.Name)'] }">
                     <td><input type="checkbox" v-bind:checked="showMods['@Model.GetSlug(mod.Name)']" v-bind:class="{ invisible: !anyModsHidden }" /></td>
-                    <td v-pre>
-                        <strong>@mod.Name</strong> @mod.Version
-                        @if (contentPacks != null && contentPacks.TryGetValue(mod.Name, out LogModInfo[] contentPackList))
+                    <td>
+                        <strong v-pre>@mod.Name</strong> @mod.Version
+                        @if (contentPackList != null)
                         {
-                            <div class="content-packs">
+                            <div v-if="!hideContentPacks" class="content-packs">
                                 @foreach (var contentPack in contentPackList)
                                 {
                                     <text>+ @contentPack.Name @contentPack.Version</text><br />
                                 }
                             </div>
+                            <span v-else class="content-packs--short"> (+ @contentPackList.Length Content Packs)</span>
                         }
                     </td>
-                    <td v-pre>
+                    <td>
                         @mod.Author
-                        @if (contentPacks != null && contentPacks.TryGetValue(mod.Name, out contentPackList))
+                        @if (contentPackList != null)
                         {
-                            <div class="content-packs">
+                            <div v-if="!hideContentPacks" class="content-packs">
                                 @foreach (var contentPack in contentPackList)
                                 {
                                     <text>+ @contentPack.Author</text><br />
@@ -323,57 +346,67 @@ else if (log?.IsValid == true)
 
         @if (!Model.ShowRaw)
         {
+            <div id="filterHolder"></div>
             <div id="filters">
-                Filter messages:
-                <span v-bind:class="{ active: showLevels['trace'] }" v-on:click="toggleLevel('trace')">TRACE</span> |
-                <span v-bind:class="{ active: showLevels['debug'] }" v-on:click="toggleLevel('debug')">DEBUG</span> |
-                <span v-bind:class="{ active: showLevels['info'] }" v-on:click="toggleLevel('info')">INFO</span> |
-                <span v-bind:class="{ active: showLevels['alert'] }" v-on:click="toggleLevel('alert')">ALERT</span> |
-                <span v-bind:class="{ active: showLevels['warn'] }" v-on:click="toggleLevel('warn')">WARN</span> |
-                <span v-bind:class="{ active: showLevels['error'] }" v-on:click="toggleLevel('error')">ERROR</span>
+                <div class="toggles">
+                    <div>
+                        Filter messages:
+                    </div>
+                    <div>
+                        <span role="button" v-bind:class="{ active: showLevels['trace'] }" v-on:click="toggleLevel('trace')">TRACE</span> |
+                        <span role="button" v-bind:class="{ active: showLevels['debug'] }" v-on:click="toggleLevel('debug')">DEBUG</span> |
+                        <span role="button" v-bind:class="{ active: showLevels['info'] }" v-on:click="toggleLevel('info')">INFO</span> |
+                        <span role="button" v-bind:class="{ active: showLevels['alert'] }" v-on:click="toggleLevel('alert')">ALERT</span> |
+                        <span role="button" v-bind:class="{ active: showLevels['warn'] }" v-on:click="toggleLevel('warn')">WARN</span> |
+                        <span role="button" v-bind:class="{ active: showLevels['error'] }" v-on:click="toggleLevel('error')">ERROR</span>
+                        <div class="filter-text">
+                            <input
+                                type="text"
+                                v-bind:class="{ active: filterText && filterText != '' }"
+                                v-on:input="updateFilterText"
+                                placeholder="filter..."
+                            />
+                            <span role="button" v-bind:class="{ active: filterUseRegex }" v-on:click="toggleFilterUseRegex" title="Use Regular Expression">.*</span>
+                            <span role="button" v-bind:class="{ active: !filterInsensitive }" v-on:click="toggleFilterInsensitive" title="Match Case">aA</span>
+                            <span role="button" v-bind:class="{ active: filterUseWord, 'whole-word': true }" v-on:click="toggleFilterWord" title="Match Whole Word"><i>Ab</i></span>
+                            <span role="button" v-bind:class="{ active: shouldHighlight }" v-on:click="toggleHighlight" title="Highlight Matches">HL</span>
+                        </div>
+                        <filter-stats
+                            v-bind:start="start"
+                            v-bind:end="end"
+                            v-bind:pages="totalPages"
+                            v-bind:filtered="filteredMessages.length"
+                            v-bind:total="totalMessages"
+                        />
+                    </div>
+                </div>
+                <pager
+                    v-bind:page="page"
+                    v-bind:pages="totalPages"
+                    v-bind:prevPage="prevPage"
+                    v-bind:nextPage="nextPage"
+                />
             </div>
 
-            <table id="log">
-                @foreach (var message in log.Messages)
-                {
-                    string levelStr = message.Level.ToString().ToLower();
-                    string sectionStartClass = message.IsStartOfSection ? "section-start" : null;
-                    string sectionFilter = message.Section != null && !message.IsStartOfSection ? $"&& sectionsAllow('{message.Section}')" : null; // filter the message by section if applicable
+            <noscript>
+                <div>
+                    This website uses JavaScript to display a filterable table. To view this log, please either
+                    <a href="@this.Url.PlainAction("Index", "LogParser", new { id = Model.PasteID, format = LogViewFormat.RawView })">view the raw log</a>
+                    or enable JavaScript.
+                </div>
+                <br/>
+            </noscript>
 
-                    <tr class="mod @levelStr @sectionStartClass"
-                        @if (message.IsStartOfSection) { <text> v-on:click="toggleSection('@message.Section')" </text> }
-                        v-show="filtersAllow('@Model.GetSlug(message.Mod)', '@levelStr') @sectionFilter">
-                        <td v-pre>@message.Time</td>
-                        @if (screenIds.Count > 1)
-                        {
-                            <td v-pre>screen_@message.ScreenId</td>
-                        }
-                        <td v-pre>@message.Level.ToString().ToUpper()</td>
-                        <td v-pre data-title="@message.Mod">@message.Mod</td>
-                        <td>
-                            <span v-pre class="log-message-text">@message.Text</span>
-                            @if (message.IsStartOfSection)
-                            {
-                                <span class="section-toggle-message">
-                                    <template v-if="sectionsAllow('@message.Section')">
-                                        This section is shown. Click here to hide it.
-                                    </template>
-                                    <template v-else>
-                                        This section is hidden. Click here to show it.
-                                    </template>
-                                </span>
-                            }
-                        </td>
-                    </tr>
-                    if (message.Repeated > 0)
-                    {
-                        <tr class="@levelStr mod mod-repeat" v-show="filtersAllow('@Model.GetSlug(message.Mod)', '@levelStr') @sectionFilter">
-                            <td colspan="4"></td>
-                            <td v-pre><i>repeats [@message.Repeated] times.</i></td>
-                        </tr>
-                    }
-                }
-            </table>
+            <log-table>
+                <log-line
+                    v-for="msg in visibleMessages"
+                    v-bind:key="msg.id"
+                    v-bind:showScreenId="showScreenId"
+                    v-bind:message="msg"
+                    v-bind:highlight="shouldHighlight"
+                    v-bind:sectionExpanded="msg.SectionName && visibleSections.includes(msg.SectionName)"
+                />
+            </log-table>
         }
         else
         {

--- a/src/SMAPI.Web/wwwroot/Content/css/log-parser.css
+++ b/src/SMAPI.Web/wwwroot/Content/css/log-parser.css
@@ -148,6 +148,10 @@ table caption {
     font-style: italic;
 }
 
+.content-packs--short {
+    opacity: 0.75;
+}
+
 #metadata td:first-child {
     padding-right: 5px;
 }
@@ -158,8 +162,58 @@ table caption {
 
 #filters {
     margin: 1em 0 0 0;
-    padding: 0;
+    padding: 0 0 0.5em;
+    display: flex;
+    justify-content: space-between;
+    width: calc(100vw - 16em);
+}
+
+#filters > div {
+    align-self: center;
+}
+
+#filters .toggles {
+    display: flex;
+}
+
+#filters .toggles > div:first-child {
     font-weight: bold;
+    padding: 0.2em 1em 0 0;
+}
+
+#filters .filter-text {
+    margin-top: 0.5em;
+}
+
+#filters .stats {
+    margin-top: 0.5em;
+    font-size: 0.75em;
+}
+
+#filters.sticky {
+    position: fixed;
+    top: 0;
+    left: 0em;
+    background: #fff;
+    margin: 0;
+    padding: 0.5em;
+    width: calc(100% - 1em);
+}
+
+@media (min-width: 1020px) and (max-width: 1199px) {
+    #filters:not(.sticky) {
+        width: calc(100vw - 13em);
+    }
+}
+
+@media (max-width: 1019px) {
+    #filters:not(.sticky) {
+        width: calc(100vw - 3em);
+    }
+
+    #filters {
+        display: block;
+    }
 }
 
 #filters span {
@@ -173,6 +227,17 @@ table caption {
     color: #000;
     border-color: #880000;
     background-color: #fcc;
+
+    user-select: none;
+}
+
+#filters .filter-text span {
+    padding: 3px 0.5em;
+}
+
+#filters .whole-word i {
+    padding: 0 1px;
+    border: 1px dashed;
 }
 
 #filters span:hover {
@@ -188,11 +253,48 @@ table caption {
     background: #efe;
 }
 
+#filters .pager {
+    margin-top: 0.5em;
+    text-align: right;
+}
+
+#filters .pager div {
+    margin-top: 0.5em;
+}
+
+#filters .pager div span {
+    padding: 0 0.5em;
+    margin: 0 1px;
+}
+
+#filters .pager span {
+    background-color: #eee;
+    border-color: #888;
+}
+
+#filters .pager span.active {
+    font-weight: bold;
+    border-color: transparent;
+    background: transparent;
+    cursor: unset;
+}
+
+#filters .pager span.disabled {
+    opacity: 0.3;
+    cursor: unset;
+}
+
+#filters .pager span:not(.disabled):hover {
+    background-color: #fff;
+}
+
+
 /*********
 ** Log
 *********/
 #log .mod-repeat {
     font-size: 0.85em;
+    font-style: italic;
 }
 
 #log .trace {
@@ -235,6 +337,11 @@ table caption {
 
 #log .log-message-text {
     white-space: pre-wrap;
+}
+
+#log .log-message-text strong {
+    background-color: yellow;
+    font-weight: normal;
 }
 
 #log {

--- a/src/SMAPI.Web/wwwroot/Content/css/log-parser.css
+++ b/src/SMAPI.Web/wwwroot/Content/css/log-parser.css
@@ -113,7 +113,7 @@ table caption {
 }
 
 .table tr {
-    background: #eee
+    background: #eee;
 }
 
 #mods span.notice {
@@ -148,8 +148,10 @@ table caption {
     font-style: italic;
 }
 
-.content-packs--short {
+.table .content-packs-collapsed {
     opacity: 0.75;
+    font-size: 0.9em;
+    font-style: italic;
 }
 
 #metadata td:first-child {
@@ -157,7 +159,7 @@ table caption {
 }
 
 .table tr:nth-child(even) {
-    background: #fff
+    background: #fff;
 }
 
 #filters {

--- a/src/SMAPI.Web/wwwroot/Content/js/log-parser.js
+++ b/src/SMAPI.Web/wwwroot/Content/js/log-parser.js
@@ -84,12 +84,12 @@ smapi.changePage = function (event) {
 }
 
 
-smapi.logParser = function (data, sectionUrl) {
-    if (!data)
-        data = {};
+smapi.logParser = function (state, sectionUrl) {
+    if (!state)
+        state = {};
 
     // internal filter counts
-    var stats = data.stats = {
+    var stats = state.stats = {
         modsShown: 0,
         modsHidden: 0
     };
@@ -98,9 +98,9 @@ smapi.logParser = function (data, sectionUrl) {
         // counts
         stats.modsShown = 0;
         stats.modsHidden = 0;
-        for (var key in data.showMods) {
-            if (data.showMods.hasOwnProperty(key)) {
-                if (data.showMods[key])
+        for (var key in state.showMods) {
+            if (state.showMods.hasOwnProperty(key)) {
+                if (state.showMods[key])
                     stats.modsShown++;
                 else
                     stats.modsHidden++;
@@ -165,38 +165,38 @@ smapi.logParser = function (data, sectionUrl) {
         messages = [];
 
     // set local time started
-    if (data.logStarted)
-        data.localTimeStarted = ("0" + data.logStarted.getHours()).slice(-2) + ":" + ("0" + data.logStarted.getMinutes()).slice(-2);
+    if (state.logStarted)
+        state.localTimeStarted = ("0" + state.logStarted.getHours()).slice(-2) + ":" + ("0" + state.logStarted.getMinutes()).slice(-2);
 
     // Add some properties to the data we're passing to Vue.
-    data.totalMessages = messages.length;
+    state.totalMessages = messages.length;
 
-    data.filterText = '';
-    data.filterRegex = '';
+    state.filterText = '';
+    state.filterRegex = '';
 
-    data.showContentPacks = true;
-    data.useHighlight = true;
-    data.useRegex = false;
-    data.useInsensitive = true;
-    data.useWord = false;
+    state.showContentPacks = true;
+    state.useHighlight = true;
+    state.useRegex = false;
+    state.useInsensitive = true;
+    state.useWord = false;
 
-    data.perPage = 1000;
-    data.page = 1;
+    state.perPage = 1000;
+    state.page = 1;
 
     // Now load these values.
     if (localStorage.settings) {
         try {
             const saved = JSON.parse(localStorage.settings);
             if (saved.hasOwnProperty('showContentPacks'))
-                data.showContentPacks = saved.showContentPacks;
+                state.showContentPacks = saved.showContentPacks;
             if (saved.hasOwnProperty('useHighlight'))
                 dat.useHighlight = saved.useHighlight;
             if (saved.hasOwnProperty('useRegex'))
-                data.useRegex = saved.useRegex;
+                state.useRegex = saved.useRegex;
             if (saved.hasOwnProperty('useInsensitive'))
-                data.useInsensitive = saved.useInsensitive;
+                state.useInsensitive = saved.useInsensitive;
             if (saved.hasOwnProperty('useWord'))
-                data.useWord = saved.useWord;
+                state.useWord = saved.useWord;
         } catch { /* ignore errors */ }
     }
 
@@ -458,7 +458,7 @@ smapi.logParser = function (data, sectionUrl) {
     // init app
     app = new Vue({
         el: '#output',
-        data: data,
+        data: state,
         computed: {
             anyModsHidden: function () {
                 return stats.modsHidden > 0;
@@ -474,14 +474,14 @@ smapi.logParser = function (data, sectionUrl) {
             // weird about accessing data entries on the app rather than
             // computed properties.
             hideContentPacks: function () {
-                return !data.showContentPacks;
+                return !state.showContentPacks;
             },
 
             // Filter messages for visibility.
-            filterUseRegex: function () { return data.useRegex; },
-            filterInsensitive: function () { return data.useInsensitive; },
-            filterUseWord: function () { return data.useWord; },
-            shouldHighlight: function () { return data.useHighlight; },
+            filterUseRegex: function () { return state.useRegex; },
+            filterInsensitive: function () { return state.useInsensitive; },
+            filterUseWord: function () { return state.useWord; },
+            shouldHighlight: function () { return state.useHighlight; },
 
             filteredMessages: function () {
                 if (!messages)
@@ -520,13 +520,13 @@ smapi.logParser = function (data, sectionUrl) {
 
             // And the rest are about pagination.
             start: function () {
-                return (this.page - 1) * data.perPage;
+                return (this.page - 1) * state.perPage;
             },
             end: function () {
                 return this.start + this.visibleMessages.length;
             },
             totalPages: function () {
-                return Math.ceil(this.filteredMessages.length / data.perPage);
+                return Math.ceil(this.filteredMessages.length / state.perPage);
             },
             // 
             visibleMessages: function () {
@@ -534,7 +534,7 @@ smapi.logParser = function (data, sectionUrl) {
                     return this.filteredMessages;
 
                 const start = this.start;
-                const end = start + data.perPage;
+                const end = start + state.perPage;
 
                 return this.filteredMessages.slice(start, end);
             }
@@ -555,7 +555,7 @@ smapi.logParser = function (data, sectionUrl) {
                     try {
                         const perPage = parseInt(params.get('PerPage'));
                         if (!isNaN(perPage) && isFinite(perPage) && perPage > 0)
-                            data.perPage = perPage;
+                            state.perPage = perPage;
                     } catch { /* ignore errors */ }
 
                 if (params.has('Page'))
@@ -567,37 +567,37 @@ smapi.logParser = function (data, sectionUrl) {
             },
 
             toggleLevel: function (id) {
-                if (!data.enableFilters)
+                if (!state.enableFilters)
                     return;
 
                 this.showLevels[id] = !this.showLevels[id];
             },
 
             toggleContentPacks: function () {
-                data.showContentPacks = !data.showContentPacks;
+                state.showContentPacks = !state.showContentPacks;
                 this.saveSettings();
             },
 
             toggleFilterUseRegex: function () {
-                data.useRegex = !data.useRegex;
+                state.useRegex = !state.useRegex;
                 this.saveSettings();
                 this.updateFilterText();
             },
 
             toggleFilterInsensitive: function () {
-                data.useInsensitive = !data.useInsensitive;
+                state.useInsensitive = !state.useInsensitive;
                 this.saveSettings();
                 this.updateFilterText();
             },
 
             toggleFilterWord: function () {
-                data.useWord = !data.useWord;
+                state.useWord = !state.useWord;
                 this.saveSettings();
                 this.updateFilterText();
             },
 
             toggleHighlight: function () {
-                data.useHighlight = !data.useHighlight;
+                state.useHighlight = !state.useHighlight;
                 this.saveSettings();
             },
 
@@ -626,11 +626,11 @@ smapi.logParser = function (data, sectionUrl) {
             // the user opens a log.
             saveSettings: function () {
                 localStorage.settings = JSON.stringify({
-                    showContentPacks: data.showContentPacks,
-                    useRegex: data.useRegex,
-                    useInsensitive: data.useInsensitive,
-                    useWord: data.useWord,
-                    useHighlight: data.useHighlight
+                    showContentPacks: state.showContentPacks,
+                    useRegex: state.useRegex,
+                    useInsensitive: state.useInsensitive,
+                    useWord: state.useWord,
+                    useHighlight: state.useHighlight
                 });
             },
 
@@ -640,8 +640,8 @@ smapi.logParser = function (data, sectionUrl) {
             // really care about.
             updateUrl: function () {
                 const url = new URL(location);
-                url.searchParams.set('Page', data.page);
-                url.searchParams.set('PerPage', data.perPage);
+                url.searchParams.set('Page', state.page);
+                url.searchParams.set('PerPage', state.perPage);
 
                 window.history.replaceState(null, document.title, url.toString());
             },
@@ -656,17 +656,17 @@ smapi.logParser = function (data, sectionUrl) {
                     this.filterText = '';
                     this.filterRegex = null;
                 } else {
-                    if (!data.useRegex)
+                    if (!state.useRegex)
                         text = escapeRegex(text);
                     this.filterRegex = new RegExp(
-                        data.useWord ? `\\b${text}\\b` : text,
-                        data.useInsensitive ? 'ig' : 'g'
+                        state.useWord ? `\\b${text}\\b` : text,
+                        state.useInsensitive ? 'ig' : 'g'
                     );
                 }
             }, 250),
 
             toggleMod: function (id) {
-                if (!data.enableFilters)
+                if (!state.enableFilters)
                     return;
 
                 var curShown = this.showMods[id];
@@ -689,14 +689,14 @@ smapi.logParser = function (data, sectionUrl) {
             },
 
             toggleSection: function (name) {
-                if (!data.enableFilters)
+                if (!state.enableFilters)
                     return;
 
                 this.showSections[name] = !this.showSections[name];
             },
 
             showAllMods: function () {
-                if (!data.enableFilters)
+                if (!state.enableFilters)
                     return;
 
                 for (var key in this.showMods) {
@@ -708,7 +708,7 @@ smapi.logParser = function (data, sectionUrl) {
             },
 
             hideAllMods: function () {
-                if (!data.enableFilters)
+                if (!state.enableFilters)
                     return;
 
                 for (var key in this.showMods) {

--- a/src/SMAPI.Web/wwwroot/Content/js/log-parser.js
+++ b/src/SMAPI.Web/wwwroot/Content/js/log-parser.js
@@ -162,8 +162,14 @@ smapi.logParser = function (state) {
         }
     }
 
+    // load raw log data
+    {
+        const dataElement = document.querySelector(state.dataElement);
+        state.data = JSON.parse(dataElement.textContent.trim());
+    }
+
     // preprocess data for display
-    state.messages = state.data?.messages || [];
+    state.messages = state.data.messages || [];
     if (state.messages.length) {
         const levels = state.data.logLevels;
         const sections = state.data.sections;

--- a/src/SMAPI.Web/wwwroot/Content/js/log-parser.js
+++ b/src/SMAPI.Web/wwwroot/Content/js/log-parser.js
@@ -2,12 +2,98 @@
 
 var smapi = smapi || {};
 var app;
+var messages;
+
+
+// Necessary helper method for updating our text filter in a performant way.
+// Wouldn't want to update it for every individually typed character.
+function debounce(fn, delay) {
+    var timeoutID = null
+    return function () {
+        clearTimeout(timeoutID)
+        var args = arguments
+        var that = this
+        timeoutID = setTimeout(function () {
+            fn.apply(that, args)
+        }, delay)
+    }
+}
+
+// Case insensitive text searching and match word searching is best done in
+// regex, so if the user isn't trying to use regex, escape their input.
+function escapeRegex(text) {
+    return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Use a scroll event to apply a sticky effect to the filters / pagination
+// bar. We can't just use "position: sticky" due to how the page is structured
+// but this works well enough.
+$(function () {
+    let sticking = false;
+
+    document.addEventListener('scroll', function (event) {
+        const filters = document.getElementById('filters');
+        const holder = document.getElementById('filterHolder');
+        if (!filters || !holder)
+            return;
+
+        const offset = holder.offsetTop;
+        const should_stick = window.pageYOffset > offset;
+        if (should_stick === sticking)
+            return;
+
+        sticking = should_stick;
+        if (sticking) {
+            holder.style.marginBottom = `calc(1em + ${filters.offsetHeight}px)`;
+            filters.classList.add('sticky');
+        } else {
+            filters.classList.remove('sticky');
+            holder.style.marginBottom = '';
+        }
+    });
+});
+
+// This method is called when we click a log line to toggle the visibility
+// of a section. Binding methods is problematic with functional components
+// so we just use the `data-section` parameter and our global reference
+// to the app.
+smapi.clickLogLine = function (event) {
+    app.toggleSection(event.currentTarget.dataset.section);
+    event.preventDefault();
+    return false;
+}
+
+// And these methods are called when doing pagination. Just makes things
+// easier, so may as well use helpers.
+smapi.prevPage = function () {
+    app.prevPage();
+}
+
+smapi.nextPage = function () {
+    app.nextPage();
+}
+
+smapi.changePage = function (event) {
+    if (typeof event === 'number')
+        app.changePage(event);
+    else if (event) {
+        const page = parseInt(event.currentTarget.dataset.page);
+        if (!isNaN(page) && isFinite(page))
+            app.changePage(page);
+    }
+}
+
+
 smapi.logParser = function (data, sectionUrl) {
+    if (!data)
+        data = {};
+
     // internal filter counts
     var stats = data.stats = {
         modsShown: 0,
         modsHidden: 0
     };
+
     function updateModFilters() {
         // counts
         stats.modsShown = 0;
@@ -22,9 +108,356 @@ smapi.logParser = function (data, sectionUrl) {
         }
     }
 
+    // load our data
+
+    // Rather than pre-rendering the list elements into the document, we read
+    // a lot of JSON and use Vue to build the list. This is a lot more
+    // performant and easier on memory.Our JSON is stored in special script
+    // tags, that we later remove to let the browser clean up even more memory.
+    let nodeParsedMessages = document.querySelector('script#parsedMessages');
+    if (nodeParsedMessages) {
+        messages = JSON.parse(nodeParsedMessages.textContent) || [];
+        const logLevels = JSON.parse(document.querySelector('script#logLevels').textContent) || {};
+        const logSections = JSON.parse(document.querySelector('script#logSections').textContent) || {};
+        const modSlugs = JSON.parse(document.querySelector('script#modSlugs').textContent) || {};
+
+        // Remove all references to the script tags and remove them from the
+        // DOM so that the browser can clean them up.
+        nodeParsedMessages.remove();
+        document.querySelector('script#logLevels').remove();
+        document.querySelector('script#logSections').remove();
+        document.querySelector('script#modSlugs').remove();
+        nodeParsedMessages = null;
+
+        // Pre-process the messages since they aren't quite serialized in
+        // the format we want. We also want to freeze every last message
+        // so that Vue won't install its change listening behavior.
+        for (let i = 0, length = messages.length; i < length; i++) {
+            const msg = messages[i];
+            msg.id = i;
+            msg.LevelName = logLevels && logLevels[msg.Level];
+            msg.SectionName = logSections && logSections[msg.Section];
+            msg.ModSlug = modSlugs && modSlugs[msg.Mod] || msg.Mod;
+
+            // For repeated messages, since our <log-line /> component
+            // can't return two rows, just insert a second message
+            // which will display as the message repeated notice.
+            if (msg.Repeated > 0 && ! msg.isRepeated) {
+                const second = {
+                    id: i + 1,
+                    Level: msg.Level,
+                    Section: msg.Section,
+                    Mod: msg.Mod,
+                    Repeated: msg.Repeated,
+                    isRepeated: true,
+                };
+
+                messages.splice(i + 1, 0, second);
+                length++;
+            }
+
+            Object.freeze(msg);
+        }
+
+        Object.freeze(messages);
+
+    } else
+        messages = [];
+
     // set local time started
-    if (data)
+    if (data.logStarted)
         data.localTimeStarted = ("0" + data.logStarted.getHours()).slice(-2) + ":" + ("0" + data.logStarted.getMinutes()).slice(-2);
+
+    // Add some properties to the data we're passing to Vue.
+    data.totalMessages = messages.length;
+
+    data.filterText = '';
+    data.filterRegex = '';
+
+    data.showContentPacks = true;
+    data.useHighlight = true;
+    data.useRegex = false;
+    data.useInsensitive = true;
+    data.useWord = false;
+
+    data.perPage = 1000;
+    data.page = 1;
+
+    // Now load these values.
+    if (localStorage.settings) {
+        try {
+            const saved = JSON.parse(localStorage.settings);
+            if (saved.hasOwnProperty('showContentPacks'))
+                data.showContentPacks = saved.showContentPacks;
+            if (saved.hasOwnProperty('useHighlight'))
+                dat.useHighlight = saved.useHighlight;
+            if (saved.hasOwnProperty('useRegex'))
+                data.useRegex = saved.useRegex;
+            if (saved.hasOwnProperty('useInsensitive'))
+                data.useInsensitive = saved.useInsensitive;
+            if (saved.hasOwnProperty('useWord'))
+                data.useWord = saved.useWord;
+        } catch { /* ignore errors */ }
+    }
+
+    // This would be easier if we could just use JSX but this project doesn't
+    // have a proper JavaScript build environment and I really don't feel
+    // like setting one up.
+
+    // Add a number formatter so that our numbers look nicer.
+    const fmt = window.Intl && Intl.NumberFormat && new Intl.NumberFormat();
+    function formatNumber(value) {
+        if (!fmt || !fmt.format) return `${value}`;
+        return fmt.format(value);
+    }
+    Vue.filter('number', formatNumber);
+
+    // Strictly speaking, we don't need this. However, due to the way our
+    // Vue template is living in-page the browser is "helpful" and moves
+    // our <log-line />s outside of a basic <table> since obviously they
+    // aren't table rows and don't belong inside a table. By using another
+    // Vue component, we avoid that.
+    Vue.component('log-table', {
+        functional: true,
+        render: function (createElement, context) {
+            return createElement('table', {
+                attrs: {
+                    id: 'log'
+                }
+            }, context.children);
+        }
+    });
+
+    // The <filter-stats /> component draws a nice message under the filters
+    // telling a user how many messages match their filters, and also expands
+    // on how many of them they're seeing because of pagination.
+    Vue.component('filter-stats', {
+        functional: true,
+        render: function (createElement, context) {
+            const props = context.props;
+            if (props.pages > 1)
+                return createElement('div', {
+                    class: 'stats'
+                }, [
+                    'showing ',
+                    createElement('strong', formatNumber(props.start + 1)),
+                    ' to ',
+                    createElement('strong', formatNumber(props.end)),
+                    ' of ',
+                    createElement('strong', formatNumber(props.filtered)),
+                    ' (total: ',
+                    createElement('strong', formatNumber(props.total)),
+                    ')'
+                ]);
+
+            return createElement('div', {
+                class: 'stats'
+            }, [
+                'showing ',
+                createElement('strong', formatNumber(props.filtered)),
+                ' out of ',
+                createElement('strong', formatNumber(props.total))
+            ]);
+        }
+    });
+
+    // Next up we have <pager /> which renders the pagination list. This has a
+    // helper method to make building the list of links easier.
+    function addPageLink(page, links, visited, createElement, currentPage) {
+        if (visited.has(page))
+            return;
+
+        if (page > 1 && !visited.has(page - 1))
+            links.push(' … ');
+
+        visited.add(page);
+        links.push(createElement('span', {
+            class: page == currentPage ? 'active' : null,
+            attrs: {
+                'data-page': page
+            },
+            on: {
+                click: smapi.changePage
+            }
+        }, formatNumber(page)));
+    }
+
+    Vue.component('pager', {
+        functional: true,
+        render: function (createElement, context) {
+            const props = context.props;
+            if (props.pages <= 1)
+                return null;
+
+            const visited = new Set;
+            const pageLinks = [];
+
+            for (let i = 1; i <= 2; i++)
+                addPageLink(i, pageLinks, visited, createElement, props.page);
+
+            for (let i = props.page - 2; i <= props.page + 2; i++) {
+                if (i < 1 || i > props.pages)
+                    continue;
+
+                addPageLink(i, pageLinks, visited, createElement, props.page);
+            }
+
+            for (let i = props.pages - 2; i <= props.pages; i++) {
+                if (i < 1)
+                    continue;
+
+                addPageLink(i, pageLinks, visited, createElement, props.page);
+            }
+
+            return createElement('div', {
+                class: 'pager'
+            }, [
+                createElement('span', {
+                    class: props.page <= 1 ? 'disabled' : null,
+                    on: {
+                        click: smapi.prevPage
+                    }
+                }, 'Prev'),
+                ' ',
+                'Page ',
+                formatNumber(props.page),
+                ' of ',
+                formatNumber(props.pages),
+                ' ',
+                createElement('span', {
+                    class: props.page >= props.pages ? 'disabled' : null,
+                    on: {
+                        click: smapi.nextPage
+                    }
+                }, 'Next'),
+                createElement('div', {}, pageLinks)
+            ]);
+        }
+    });
+
+    // Our <log-line /> functional component draws each log line.
+    Vue.component('log-line', {
+        functional: true,
+        props: {
+            showScreenId: {
+                type: Boolean,
+                required: true
+            },
+            message: {
+                type: Object,
+                required: true
+            },
+            sectionExpanded: {
+                type: Boolean,
+                required: false
+            },
+            highlight: {
+                type: Boolean,
+                required: false
+            }
+        },
+        render: function (createElement, context) {
+            const msg = context.props.message;
+            const level = msg.LevelName;
+
+            if (msg.isRepeated)
+                return createElement('tr', {
+                    class: [
+                        "mod",
+                        level,
+                        "mod-repeat"
+                    ]
+                }, [
+                    createElement('td', {
+                        attrs: {
+                            colspan: context.props.showScreenId ? 4 : 3
+                        }
+                    }, ''),
+                    createElement('td', `repeats ${msg.Repeated} times`)
+                ]);
+
+            const events = {};
+            let toggleMessage;
+            if (msg.IsStartOfSection) {
+                const visible = context.props.sectionExpanded;
+                events.click = smapi.clickLogLine;
+                toggleMessage = visible ?
+                    'This section is shown. Click here to hide it.' :
+                    'This section is hidden. Click here to show it.';
+            }
+
+            let text = msg.Text;
+            const filter = window.app && app.filterRegex;
+            if (text && filter && context.props.highlight) {
+                text = [];
+                let match, consumed = 0, idx = 0;
+                filter.lastIndex = -1;
+
+                // Our logic to highlight the text is a bit funky because we
+                // want to group consecutive matches to avoid a situation
+                // where a ton of single characters are in their own elements
+                // if the user gives us bad input.
+
+                while (match = filter.exec(msg.Text)) {
+                    // Do we have an area of non-matching text? This
+                    // happens if the new match's index is further
+                    // along than the last index.
+                    if (match.index > idx) {
+                        // Alright, do we have a previous match? If
+                        // we do, we need to consume some text.
+                        if (consumed < idx)
+                            text.push(createElement('strong', {}, msg.Text.slice(consumed, idx)));
+
+                        text.push(msg.Text.slice(idx, match.index));
+                        consumed = match.index;
+                    }
+
+                    idx = match.index + match[0].length;
+                }
+
+                // Add any trailing text after the last match was found.
+                if (consumed < msg.Text.length) {
+                    if (consumed < idx)
+                        text.push(createElement('strong', {}, msg.Text.slice(consumed, idx)));
+
+                    if (idx < msg.Text.length)
+                        text.push(msg.Text.slice(idx));
+                }
+            }
+
+            return createElement('tr', {
+                class: [
+                    "mod",
+                    level,
+                    msg.IsStartOfSection ? "section-start" : null
+                ],
+                attrs: {
+                    'data-section': msg.SectionName
+                },
+                on: events
+            }, [
+                createElement('td', msg.Time),
+                context.props.showScreenId ? createElement('td', msg.ScreenId) : null,
+                createElement('td', level.toUpperCase()),
+                createElement('td', {
+                    attrs: {
+                        'data-title': msg.Mod
+                    }
+                }, msg.Mod),
+                createElement('td', [
+                    createElement('span', {
+                        class: 'log-message-text'
+                    }, text),
+                    msg.IsStartOfSection ? createElement('span', {
+                        class: 'section-toggle-message'
+                    }, [
+                        ' ',
+                        toggleMessage
+                    ]) : null
+                ])
+            ]);
+        }
+    });
 
     // init app
     app = new Vue({
@@ -36,15 +469,212 @@ smapi.logParser = function (data, sectionUrl) {
             },
             anyModsShown: function () {
                 return stats.modsShown > 0;
+            },
+            showScreenId: function () {
+                return this.screenIds.length > 1;
+            },
+
+            // Maybe not strictly necessary, but the Vue template is being
+            // weird about accessing data entries on the app rather than
+            // computed properties.
+            visibleSections: function () {
+                const ret = [];
+                for (const [k, v] of Object.entries(this.showSections))
+                    if (v !== false)
+                        ret.push(k);
+                return ret;
+            },
+            hideContentPacks: function () {
+                return !data.showContentPacks;
+            },
+
+            // Filter messages for visibility.
+            filterUseRegex: function () { return data.useRegex; },
+            filterInsensitive: function () { return data.useInsensitive; },
+            filterUseWord: function () { return data.useWord; },
+            shouldHighlight: function () { return data.useHighlight; },
+
+            filteredMessages: function () {
+                if (!messages)
+                    return [];
+
+                const start = performance.now();
+                const ret = [];
+
+                // This is slightly faster than messages.filter(), which is
+                // important when working with absolutely huge logs.
+                for (let i = 0, length = messages.length; i < length; i++) {
+                    const msg = messages[i];
+                    if (msg.SectionName && !msg.IsStartOfSection && !this.sectionsAllow(msg.SectionName))
+                        continue;
+
+                    if (!this.filtersAllow(msg.ModSlug, msg.LevelName))
+                        continue;
+
+                    let text = msg.Text || (i > 0 ? messages[i - 1].Text : null);
+
+                    if (this.filterRegex) {
+                        this.filterRegex.lastIndex = -1;
+                        if (!text || !this.filterRegex.test(text))
+                            continue;
+                    } else if (this.filterText && (!text || text.indexOf(this.filterText) == -1))
+                        continue;
+
+                    ret.push(msg);
+                }
+
+                const end = performance.now();
+                console.log(`filter took ${end - start}ms`);
+
+                return ret;
+            },
+
+            // And the rest are about pagination.
+            start: function () {
+                return (this.page - 1) * data.perPage;
+            },
+            end: function () {
+                return this.start + this.visibleMessages.length;
+            },
+            totalPages: function () {
+                return Math.ceil(this.filteredMessages.length / data.perPage);
+            },
+            // 
+            visibleMessages: function () {
+                if (this.totalPages <= 1)
+                    return this.filteredMessages;
+
+                const start = this.start;
+                const end = start + data.perPage;
+
+                return this.filteredMessages.slice(start, end);
             }
         },
+        created: function () {
+            this.loadFromUrl = this.loadFromUrl.bind(this);
+            window.addEventListener('popstate', this.loadFromUrl);
+            this.loadFromUrl();
+        },
         methods: {
+            // Mostly I wanted people to know they can override the PerPage
+            // message count with a URL parameter, but we can read Page too.
+            // In the future maybe we should read *all* filter state so a
+            // user can link to their exact page state for someone else?
+            loadFromUrl: function () {
+                const params = new URL(location).searchParams;
+                if (params.has('PerPage'))
+                    try {
+                        const perPage = parseInt(params.get('PerPage'));
+                        if (!isNaN(perPage) && isFinite(perPage) && perPage > 0)
+                            data.perPage = perPage;
+                    } catch { /* ignore errors */ }
+
+                if (params.has('Page'))
+                    try {
+                        const page = parseInt(params.get('Page'));
+                        if (!isNaN(page) && isFinite(page) && page > 0)
+                            this.page = page;
+                    } catch { /* ignore errors */ }
+            },
+
             toggleLevel: function (id) {
                 if (!data.enableFilters)
                     return;
 
                 this.showLevels[id] = !this.showLevels[id];
             },
+
+            toggleContentPacks: function () {
+                data.showContentPacks = !data.showContentPacks;
+                this.saveSettings();
+            },
+
+            toggleFilterUseRegex: function () {
+                data.useRegex = !data.useRegex;
+                this.saveSettings();
+                this.updateFilterText();
+            },
+
+            toggleFilterInsensitive: function () {
+                data.useInsensitive = !data.useInsensitive;
+                this.saveSettings();
+                this.updateFilterText();
+            },
+
+            toggleFilterWord: function () {
+                data.useWord = !data.useWord;
+                this.saveSettings();
+                this.updateFilterText();
+            },
+
+            toggleHighlight: function () {
+                data.useHighlight = !data.useHighlight;
+                this.saveSettings();
+            },
+
+            prevPage: function () {
+                if (this.page <= 1)
+                    return;
+                this.page--;
+                this.updateUrl();
+            },
+
+            nextPage: function () {
+                if (this.page >= this.totalPages)
+                    return;
+                this.page++;
+                this.updateUrl();
+            },
+
+            changePage: function (page) {
+                if (page < 1 || page > this.totalPages)
+                    return;
+                this.page = page;
+                this.updateUrl();
+            },
+
+            // Persist settings into localStorage for use the next time
+            // the user opens a log.
+            saveSettings: function () {
+                localStorage.settings = JSON.stringify({
+                    showContentPacks: data.showContentPacks,
+                    useRegex: data.useRegex,
+                    useInsensitive: data.useInsensitive,
+                    useWord: data.useWord,
+                    useHighlight: data.useHighlight
+                });
+            },
+
+            // Whenever the page is changed, replace the current page URL. Using
+            // replaceState rather than pushState to avoid filling the tab history
+            // with tons of useless history steps the user probably doesn't
+            // really care about.
+            updateUrl: function () {
+                const url = new URL(location);
+                url.searchParams.set('Page', data.page);
+                url.searchParams.set('PerPage', data.perPage);
+
+                window.history.replaceState(null, document.title, url.toString());
+            },
+
+            // We don't want to update the filter text often, so use a debounce with
+            // a quarter second delay. We basically always build a regular expression
+            // since we use it for highlighting, and it also make case insensitivity
+            // much easier.
+            updateFilterText: debounce(function () {
+                let text = this.filterText = document.querySelector('input[type=text]').value;
+                if (!text || !text.length) {
+                    this.filterText = '';
+                    this.filterRegex = null;
+                } else {
+                    if (!data.useRegex)
+                        text = escapeRegex(text);
+                    this.filterRegex = new RegExp(
+                        data.useWord ? `\\b${text}\\b` : text,
+                        data.useInsensitive ? 'ig' : 'g'
+                    );
+                }
+            }, 250),
 
             toggleMod: function (id) {
                 if (!data.enableFilters)

--- a/src/SMAPI.Web/wwwroot/Content/js/log-parser.js
+++ b/src/SMAPI.Web/wwwroot/Content/js/log-parser.js
@@ -166,6 +166,7 @@ smapi.logParser = function (state) {
     {
         const dataElement = document.querySelector(state.dataElement);
         state.data = JSON.parse(dataElement.textContent.trim());
+        dataElement.remove(); // let browser unload the data element since we won't need it anymore
     }
 
     // preprocess data for display

--- a/src/SMAPI.Web/wwwroot/Content/js/log-parser.js
+++ b/src/SMAPI.Web/wwwroot/Content/js/log-parser.js
@@ -347,10 +347,6 @@ smapi.logParser = function (data, sectionUrl) {
                 type: Object,
                 required: true
             },
-            sectionExpanded: {
-                type: Boolean,
-                required: false
-            },
             highlight: {
                 type: Boolean,
                 required: false
@@ -379,7 +375,7 @@ smapi.logParser = function (data, sectionUrl) {
             const events = {};
             let toggleMessage;
             if (msg.IsStartOfSection) {
-                const visible = context.props.sectionExpanded;
+                const visible = msg.SectionName && window.app && app.sectionsAllow(msg.SectionName);
                 events.click = smapi.clickLogLine;
                 toggleMessage = visible ?
                     'This section is shown. Click here to hide it.' :
@@ -477,13 +473,6 @@ smapi.logParser = function (data, sectionUrl) {
             // Maybe not strictly necessary, but the Vue template is being
             // weird about accessing data entries on the app rather than
             // computed properties.
-            visibleSections: function () {
-                const ret = [];
-                for (const [k, v] of Object.entries(this.showSections))
-                    if (v !== false)
-                        ret.push(k);
-                return ret;
-            },
             hideContentPacks: function () {
                 return !data.showContentPacks;
             },

--- a/src/SMAPI.Web/wwwroot/Content/js/log-parser.js
+++ b/src/SMAPI.Web/wwwroot/Content/js/log-parser.js
@@ -22,7 +22,7 @@ function debounce(fn, delay) {
 // Case insensitive text searching and match word searching is best done in
 // regex, so if the user isn't trying to use regex, escape their input.
 function escapeRegex(text) {
-    return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 // Use a scroll event to apply a sticky effect to the filters / pagination
@@ -31,9 +31,9 @@ function escapeRegex(text) {
 $(function () {
     let sticking = false;
 
-    document.addEventListener('scroll', function (event) {
-        const filters = document.getElementById('filters');
-        const holder = document.getElementById('filterHolder');
+    document.addEventListener("scroll", function (event) {
+        const filters = document.getElementById("filters");
+        const holder = document.getElementById("filterHolder");
         if (!filters || !holder)
             return;
 
@@ -45,10 +45,10 @@ $(function () {
         sticking = should_stick;
         if (sticking) {
             holder.style.marginBottom = `calc(1em + ${filters.offsetHeight}px)`;
-            filters.classList.add('sticky');
+            filters.classList.add("sticky");
         } else {
-            filters.classList.remove('sticky');
-            holder.style.marginBottom = '';
+            filters.classList.remove("sticky");
+            holder.style.marginBottom = "";
         }
     });
 });
@@ -74,7 +74,7 @@ smapi.nextPage = function () {
 }
 
 smapi.changePage = function (event) {
-    if (typeof event === 'number')
+    if (typeof event === "number")
         app.changePage(event);
     else if (event) {
         const page = parseInt(event.currentTarget.dataset.page);
@@ -114,19 +114,19 @@ smapi.logParser = function (state, sectionUrl) {
     // a lot of JSON and use Vue to build the list. This is a lot more
     // performant and easier on memory.Our JSON is stored in special script
     // tags, that we later remove to let the browser clean up even more memory.
-    let nodeParsedMessages = document.querySelector('script#parsedMessages');
+    let nodeParsedMessages = document.querySelector("script#parsedMessages");
     if (nodeParsedMessages) {
         messages = JSON.parse(nodeParsedMessages.textContent) || [];
-        const logLevels = JSON.parse(document.querySelector('script#logLevels').textContent) || {};
-        const logSections = JSON.parse(document.querySelector('script#logSections').textContent) || {};
-        const modSlugs = JSON.parse(document.querySelector('script#modSlugs').textContent) || {};
+        const logLevels = JSON.parse(document.querySelector("script#logLevels").textContent) || {};
+        const logSections = JSON.parse(document.querySelector("script#logSections").textContent) || {};
+        const modSlugs = JSON.parse(document.querySelector("script#modSlugs").textContent) || {};
 
         // Remove all references to the script tags and remove them from the
         // DOM so that the browser can clean them up.
         nodeParsedMessages.remove();
-        document.querySelector('script#logLevels').remove();
-        document.querySelector('script#logSections').remove();
-        document.querySelector('script#modSlugs').remove();
+        document.querySelector("script#logLevels").remove();
+        document.querySelector("script#logSections").remove();
+        document.querySelector("script#modSlugs").remove();
         nodeParsedMessages = null;
 
         // Pre-process the messages since they aren't quite serialized in
@@ -171,8 +171,8 @@ smapi.logParser = function (state, sectionUrl) {
     // Add some properties to the data we're passing to Vue.
     state.totalMessages = messages.length;
 
-    state.filterText = '';
-    state.filterRegex = '';
+    state.filterText = "";
+    state.filterRegex = "";
 
     state.showContentPacks = true;
     state.useHighlight = true;
@@ -187,15 +187,15 @@ smapi.logParser = function (state, sectionUrl) {
     if (localStorage.settings) {
         try {
             const saved = JSON.parse(localStorage.settings);
-            if (saved.hasOwnProperty('showContentPacks'))
+            if (saved.hasOwnProperty("showContentPacks"))
                 state.showContentPacks = saved.showContentPacks;
-            if (saved.hasOwnProperty('useHighlight'))
+            if (saved.hasOwnProperty("useHighlight"))
                 dat.useHighlight = saved.useHighlight;
-            if (saved.hasOwnProperty('useRegex'))
+            if (saved.hasOwnProperty("useRegex"))
                 state.useRegex = saved.useRegex;
-            if (saved.hasOwnProperty('useInsensitive'))
+            if (saved.hasOwnProperty("useInsensitive"))
                 state.useInsensitive = saved.useInsensitive;
-            if (saved.hasOwnProperty('useWord'))
+            if (saved.hasOwnProperty("useWord"))
                 state.useWord = saved.useWord;
         } catch { /* ignore errors */ }
     }
@@ -210,19 +210,19 @@ smapi.logParser = function (state, sectionUrl) {
         if (!fmt || !fmt.format) return `${value}`;
         return fmt.format(value);
     }
-    Vue.filter('number', formatNumber);
+    Vue.filter("number", formatNumber);
 
     // Strictly speaking, we don't need this. However, due to the way our
     // Vue template is living in-page the browser is "helpful" and moves
     // our <log-line />s outside of a basic <table> since obviously they
     // aren't table rows and don't belong inside a table. By using another
     // Vue component, we avoid that.
-    Vue.component('log-table', {
+    Vue.component("log-table", {
         functional: true,
         render: function (createElement, context) {
-            return createElement('table', {
+            return createElement("table", {
                 attrs: {
-                    id: 'log'
+                    id: "log"
                 }
             }, context.children);
         }
@@ -231,32 +231,32 @@ smapi.logParser = function (state, sectionUrl) {
     // The <filter-stats /> component draws a nice message under the filters
     // telling a user how many messages match their filters, and also expands
     // on how many of them they're seeing because of pagination.
-    Vue.component('filter-stats', {
+    Vue.component("filter-stats", {
         functional: true,
         render: function (createElement, context) {
             const props = context.props;
             if (props.pages > 1)
-                return createElement('div', {
-                    class: 'stats'
+                return createElement("div", {
+                    class: "stats"
                 }, [
-                    'showing ',
-                    createElement('strong', formatNumber(props.start + 1)),
-                    ' to ',
-                    createElement('strong', formatNumber(props.end)),
-                    ' of ',
-                    createElement('strong', formatNumber(props.filtered)),
-                    ' (total: ',
-                    createElement('strong', formatNumber(props.total)),
-                    ')'
+                    "showing ",
+                    createElement("strong", formatNumber(props.start + 1)),
+                    " to ",
+                    createElement("strong", formatNumber(props.end)),
+                    " of ",
+                    createElement("strong", formatNumber(props.filtered)),
+                    " (total: ",
+                    createElement("strong", formatNumber(props.total)),
+                    ")"
                 ]);
 
-            return createElement('div', {
-                class: 'stats'
+            return createElement("div", {
+                class: "stats"
             }, [
-                'showing ',
-                createElement('strong', formatNumber(props.filtered)),
-                ' out of ',
-                createElement('strong', formatNumber(props.total))
+                "showing ",
+                createElement("strong", formatNumber(props.filtered)),
+                " out of ",
+                createElement("strong", formatNumber(props.total))
             ]);
         }
     });
@@ -268,13 +268,13 @@ smapi.logParser = function (state, sectionUrl) {
             return;
 
         if (page > 1 && !visited.has(page - 1))
-            links.push(' … ');
+            links.push(" … ");
 
         visited.add(page);
-        links.push(createElement('span', {
-            class: page == currentPage ? 'active' : null,
+        links.push(createElement("span", {
+            class: page == currentPage ? "active" : null,
             attrs: {
-                'data-page': page
+                "data-page": page
             },
             on: {
                 click: smapi.changePage
@@ -282,7 +282,7 @@ smapi.logParser = function (state, sectionUrl) {
         }, formatNumber(page)));
     }
 
-    Vue.component('pager', {
+    Vue.component("pager", {
         functional: true,
         render: function (createElement, context) {
             const props = context.props;
@@ -309,34 +309,34 @@ smapi.logParser = function (state, sectionUrl) {
                 addPageLink(i, pageLinks, visited, createElement, props.page);
             }
 
-            return createElement('div', {
-                class: 'pager'
+            return createElement("div", {
+                class: "pager"
             }, [
-                createElement('span', {
-                    class: props.page <= 1 ? 'disabled' : null,
+                createElement("span", {
+                    class: props.page <= 1 ? "disabled" : null,
                     on: {
                         click: smapi.prevPage
                     }
-                }, 'Prev'),
-                ' ',
-                'Page ',
+                }, "Prev"),
+                " ",
+                "Page ",
                 formatNumber(props.page),
-                ' of ',
+                " of ",
                 formatNumber(props.pages),
-                ' ',
-                createElement('span', {
-                    class: props.page >= props.pages ? 'disabled' : null,
+                " ",
+                createElement("span", {
+                    class: props.page >= props.pages ? "disabled" : null,
                     on: {
                         click: smapi.nextPage
                     }
-                }, 'Next'),
-                createElement('div', {}, pageLinks)
+                }, "Next"),
+                createElement("div", {}, pageLinks)
             ]);
         }
     });
 
     // Our <log-line /> functional component draws each log line.
-    Vue.component('log-line', {
+    Vue.component("log-line", {
         functional: true,
         props: {
             showScreenId: {
@@ -357,19 +357,19 @@ smapi.logParser = function (state, sectionUrl) {
             const level = msg.LevelName;
 
             if (msg.isRepeated)
-                return createElement('tr', {
+                return createElement("tr", {
                     class: [
                         "mod",
                         level,
                         "mod-repeat"
                     ]
                 }, [
-                    createElement('td', {
+                    createElement("td", {
                         attrs: {
                             colspan: context.props.showScreenId ? 4 : 3
                         }
-                    }, ''),
-                    createElement('td', `repeats ${msg.Repeated} times`)
+                    }, ""),
+                    createElement("td", `repeats ${msg.Repeated} times`)
                 ]);
 
             const events = {};
@@ -377,9 +377,9 @@ smapi.logParser = function (state, sectionUrl) {
             if (msg.IsStartOfSection) {
                 const visible = msg.SectionName && window.app && app.sectionsAllow(msg.SectionName);
                 events.click = smapi.clickLogLine;
-                toggleMessage = visible ?
-                    'This section is shown. Click here to hide it.' :
-                    'This section is hidden. Click here to show it.';
+                toggleMessage = visible
+                    ? "This section is shown. Click here to hide it."
+                    : "This section is hidden. Click here to show it.";
             }
 
             let text = msg.Text;
@@ -402,7 +402,7 @@ smapi.logParser = function (state, sectionUrl) {
                         // Alright, do we have a previous match? If
                         // we do, we need to consume some text.
                         if (consumed < idx)
-                            text.push(createElement('strong', {}, msg.Text.slice(consumed, idx)));
+                            text.push(createElement("strong", {}, msg.Text.slice(consumed, idx)));
 
                         text.push(msg.Text.slice(idx, match.index));
                         consumed = match.index;
@@ -414,40 +414,40 @@ smapi.logParser = function (state, sectionUrl) {
                 // Add any trailing text after the last match was found.
                 if (consumed < msg.Text.length) {
                     if (consumed < idx)
-                        text.push(createElement('strong', {}, msg.Text.slice(consumed, idx)));
+                        text.push(createElement("strong", {}, msg.Text.slice(consumed, idx)));
 
                     if (idx < msg.Text.length)
                         text.push(msg.Text.slice(idx));
                 }
             }
 
-            return createElement('tr', {
+            return createElement("tr", {
                 class: [
                     "mod",
                     level,
                     msg.IsStartOfSection ? "section-start" : null
                 ],
                 attrs: {
-                    'data-section': msg.SectionName
+                    "data-section": msg.SectionName
                 },
                 on: events
             }, [
-                createElement('td', msg.Time),
-                context.props.showScreenId ? createElement('td', msg.ScreenId) : null,
-                createElement('td', level.toUpperCase()),
-                createElement('td', {
+                createElement("td", msg.Time),
+                context.props.showScreenId ? createElement("td", msg.ScreenId) : null,
+                createElement("td", level.toUpperCase()),
+                createElement("td", {
                     attrs: {
-                        'data-title': msg.Mod
+                        "data-title": msg.Mod
                     }
                 }, msg.Mod),
-                createElement('td', [
-                    createElement('span', {
-                        class: 'log-message-text'
+                createElement("td", [
+                    createElement("span", {
+                        class: "log-message-text"
                     }, text),
-                    msg.IsStartOfSection ? createElement('span', {
-                        class: 'section-toggle-message'
+                    msg.IsStartOfSection ? createElement("span", {
+                        class: "section-toggle-message"
                     }, [
-                        ' ',
+                        " ",
                         toggleMessage
                     ]) : null
                 ])
@@ -457,7 +457,7 @@ smapi.logParser = function (state, sectionUrl) {
 
     // init app
     app = new Vue({
-        el: '#output',
+        el: "#output",
         data: state,
         computed: {
             anyModsHidden: function () {
@@ -541,7 +541,7 @@ smapi.logParser = function (state, sectionUrl) {
         },
         created: function () {
             this.loadFromUrl = this.loadFromUrl.bind(this);
-            window.addEventListener('popstate', this.loadFromUrl);
+            window.addEventListener("popstate", this.loadFromUrl);
             this.loadFromUrl();
         },
         methods: {
@@ -551,16 +551,16 @@ smapi.logParser = function (state, sectionUrl) {
             // user can link to their exact page state for someone else?
             loadFromUrl: function () {
                 const params = new URL(location).searchParams;
-                if (params.has('PerPage'))
+                if (params.has("PerPage"))
                     try {
-                        const perPage = parseInt(params.get('PerPage'));
+                        const perPage = parseInt(params.get("PerPage"));
                         if (!isNaN(perPage) && isFinite(perPage) && perPage > 0)
                             state.perPage = perPage;
                     } catch { /* ignore errors */ }
 
-                if (params.has('Page'))
+                if (params.has("Page"))
                     try {
-                        const page = parseInt(params.get('Page'));
+                        const page = parseInt(params.get("Page"));
                         if (!isNaN(page) && isFinite(page) && page > 0)
                             this.page = page;
                     } catch { /* ignore errors */ }
@@ -640,8 +640,8 @@ smapi.logParser = function (state, sectionUrl) {
             // really care about.
             updateUrl: function () {
                 const url = new URL(location);
-                url.searchParams.set('Page', state.page);
-                url.searchParams.set('PerPage', state.perPage);
+                url.searchParams.set("Page", state.page);
+                url.searchParams.set("PerPage", state.perPage);
 
                 window.history.replaceState(null, document.title, url.toString());
             },
@@ -651,16 +651,16 @@ smapi.logParser = function (state, sectionUrl) {
             // since we use it for highlighting, and it also make case insensitivity
             // much easier.
             updateFilterText: debounce(function () {
-                let text = this.filterText = document.querySelector('input[type=text]').value;
+                let text = this.filterText = document.querySelector("input[type=text]").value;
                 if (!text || !text.length) {
-                    this.filterText = '';
+                    this.filterText = "";
                     this.filterRegex = null;
                 } else {
                     if (!state.useRegex)
                         text = escapeRegex(text);
                     this.filterRegex = new RegExp(
                         state.useWord ? `\\b${text}\\b` : text,
-                        state.useInsensitive ? 'ig' : 'g'
+                        state.useInsensitive ? "ig" : "g"
                     );
                 }
             }, 250),

--- a/src/SMAPI.sln.DotSettings
+++ b/src/SMAPI.sln.DotSettings
@@ -31,6 +31,8 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=craftables/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=crossplatform/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cutscene/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=debounce/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=debounced/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=decoratable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=devs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fallbacks/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
Hello!

This pull request overhauls the website's log parser to improve performance and usability.

Previously, the log was rendered server-side and then used as a template by a Vue application on the client in order to perform filtering. This is not great for performance, particularly for large logs. I got started on this after a user on Discord linked a log that was long enough to crash the browser tab while eating over 8GB of RAM, despite only being a 22MB log file.

To address the problem, I've removed the server-side rendering of the log. Users without JavaScript enabled can still view the raw log, so I don't see this as an issue. Instead, the server emits a JSON array with all the messages that the client parses and loads. I freeze every message object to prevent Vue from doing unnecessary instrumentation to watch for changes. I make use of Vue's computed values system to filter the list of messages, and then that list is rendered using functional components.

Further, I've added pagination to limit the number of drawn lines. I experimented with the use of a virtual list, but didn't like how the scrolling performed within the page layout. It might be something to revisit in the future.

While I was digging around, I also implemented a text input filter with support for regular expressions. This feature highlights text in log lines (by default, though it can be disabled by users in case it's slow for them).

Other misc tweaks:
* The filters bar is now sticky, staying at the top of the screen when scrolling past it.
* There is now a button to toggle the display of Content Packs in the mod list, since they can take up a lot of space when we might not actually care about the details.

I've tested this semi-thoroughly, though it's difficult given the lack of a proper JavaScript environment for SMAPI's website. Testing included using this on my phone (OnePlus 9) and it worked well there.

Screenshot demonstrating pagination, filtering, highlights, and the sticky filter bar:
![image](https://user-images.githubusercontent.com/41554123/162509403-7674d9a8-1287-493d-b4e6-f9cfb6d3cb4a.png)
