### PR TITLE
Ignore dot-prefixed files when scanning for mods

### DIFF
--- a/src/SMAPI.Toolkit/Framework/ModScanning/ModScanner.cs
+++ b/src/SMAPI.Toolkit/Framework/ModScanning/ModScanner.cs
@@ -56,7 +56,10 @@ namespace StardewModdingAPI.Toolkit.Framework.ModScanning
 
             // Windows shortcut files
             ".url",
-            ".lnk"
+            ".lnk",
+
+            // gitignore files
+            ".gitignore"
         };
 
         /// <summary>The extensions for packed content files.</summary>

--- a/src/SMAPI.Toolkit/Framework/ModScanning/ModScanner.cs
+++ b/src/SMAPI.Toolkit/Framework/ModScanning/ModScanner.cs
@@ -306,8 +306,8 @@ namespace StardewModdingAPI.Toolkit.Framework.ModScanning
         /// <param name="entry">The file or folder.</param>
         private bool IsRelevant(FileSystemInfo entry)
         {
-            // ignored file extension
-            if (entry is FileInfo file && this.IgnoreFileExtensions.Contains(file.Extension))
+            // ignored file extensions and any files starting with "."
+            if ((entry is FileInfo file) && (this.IgnoreFileExtensions.Contains(file.Extension) || file.Name.StartsWith(".")))
                 return false;
 
             // ignored entry name

--- a/src/SMAPI.Toolkit/Framework/ModScanning/ModScanner.cs
+++ b/src/SMAPI.Toolkit/Framework/ModScanning/ModScanner.cs
@@ -56,10 +56,7 @@ namespace StardewModdingAPI.Toolkit.Framework.ModScanning
 
             // Windows shortcut files
             ".url",
-            ".lnk",
-
-            // gitignore files
-            ".gitignore"
+            ".lnk"
         };
 
         /// <summary>The extensions for packed content files.</summary>


### PR DESCRIPTION
This is helpful for cases like this: https://cdn.discordapp.com/attachments/156109690059751424/962879339739885578/unknown.png

Tested this change by rebuilding the solution in debug mode and verifying that those content packs now load properly even with the .gitignore in the containing folder.