### PR TITLE
[Website] Cleanup log filtering a bit more, save state to URL

### DIFF
--- a/src/SMAPI.Web/Views/LogParser/Index.cshtml
+++ b/src/SMAPI.Web/Views/LogParser/Index.cshtml
@@ -95,16 +95,18 @@
 }
 
 @* quick navigation links *@
-@if (log != null)
-{
-    <aside id="quickNav">
-        <h4>Scroll To...</h4>
-        <ul>
-            <li><a href="#content">Top</a></li>
-            <li><a href="#filterHolder">Log Start</a></li>
-            <li><a href="#footer">Bottom</a></li>
-        </ul>
-    </aside>
+@section SidebarExtra {
+    @if (log != null)
+    {
+        <aside id="quickNav">
+            <h4>Scroll To...</h4>
+            <ul>
+                <li><a href="#content">Top</a></li>
+                <li><a href="#filterHolder">Log Start</a></li>
+                <li><a href="#footer">Bottom</a></li>
+            </ul>
+        </aside>
+    }
 }
 
 @* upload result banner *@

--- a/src/SMAPI.Web/Views/LogParser/Index.cshtml
+++ b/src/SMAPI.Web/Views/LogParser/Index.cshtml
@@ -98,14 +98,14 @@
 @section SidebarExtra {
     @if (log != null)
     {
-        <aside id="quickNav">
-            <h4>Scroll To...</h4>
+        <nav id="quickNav">
+            <h4>Scroll to...</h4>
             <ul>
                 <li><a href="#content">Top</a></li>
-                <li><a href="#filterHolder">Log Start</a></li>
+                <li><a href="#filterHolder">Log start</a></li>
                 <li><a href="#footer">Bottom</a></li>
             </ul>
-        </aside>
+        </nav>
     }
 }
 

--- a/src/SMAPI.Web/Views/LogParser/Index.cshtml
+++ b/src/SMAPI.Web/Views/LogParser/Index.cshtml
@@ -77,14 +77,19 @@
                     logStarted: new Date(@this.ForJson(log?.Timestamp)),
                     dataElement: "script#serializedData",
                     showPopup: @this.ForJson(log == null),
-                    showMods: @this.ForJson(log?.Mods.Select(p => Model.GetSlug(p.Name)).Distinct().ToDictionary(slug => slug, _ => true)),
+                    showMods: @this.ForJson(log?.Mods.Where(p => p.Loaded && !p.IsContentPack).Select(p => Model.GetSlug(p.Name)).Distinct().ToDictionary(slug => slug, _ => true)),
                     showSections: @this.ForJson(Enum.GetNames(typeof(LogSection)).ToDictionary(section => section, _ => false)),
                     showLevels: @this.ForJson(defaultFilters),
                     enableFilters: @this.ForJson(!Model.ShowRaw)
                 }
             );
 
-            new Tabby("[data-tabs]");
+            @if (log == null)
+            {
+                <text>
+                    new Tabby("[data-tabs]");
+                </text>
+            }
         });
     </script>
 }
@@ -378,6 +383,7 @@ else if (log?.IsValid == true)
                             <input
                                 type="text"
                                 v-bind:class="{ active: !!filterText }"
+                                v-model="filterText"
                                 v-on:input="updateFilterText"
                                 placeholder="search to filter log..."
                             />
@@ -390,7 +396,7 @@ else if (log?.IsValid == true)
                             v-bind:start="start"
                             v-bind:end="end"
                             v-bind:pages="totalPages"
-                            v-bind:filtered="filteredMessages.length"
+                            v-bind:filtered="filteredMessages.total"
                             v-bind:total="totalMessages"
                         />
                     </div>

--- a/src/SMAPI.Web/Views/LogParser/Index.cshtml
+++ b/src/SMAPI.Web/Views/LogParser/Index.cshtml
@@ -94,6 +94,19 @@
     </script>
 }
 
+@* quick navigation links *@
+@if (log != null)
+{
+    <aside id="quickNav">
+        <h4>Scroll To...</h4>
+        <ul>
+            <li><a href="#content">Top</a></li>
+            <li><a href="#filterHolder">Log Start</a></li>
+            <li><a href="#footer">Bottom</a></li>
+        </ul>
+    </aside>
+}
+
 @* upload result banner *@
 @if (Model.UploadError != null)
 {

--- a/src/SMAPI.Web/Views/Shared/_Layout.cshtml
+++ b/src/SMAPI.Web/Views/Shared/_Layout.cshtml
@@ -30,6 +30,8 @@
             <li><a href="@Url.PlainAction("Index", "LogParser", values: null)">Log parser</a></li>
             <li><a href="@Url.PlainAction("Index", "JsonValidator", values: null)">JSON validator</a></li>
         </ul>
+
+        @RenderSection("SidebarExtra", required: false)
     </div>
     <div id="content-column">
         <div id="content">

--- a/src/SMAPI.Web/wwwroot/Content/css/log-parser.css
+++ b/src/SMAPI.Web/wwwroot/Content/css/log-parser.css
@@ -13,9 +13,6 @@ caption {
 #output {
     padding: 10px;
     overflow: auto;
-    z-index: 1;
-    background: #fff;
-    position: relative;
 }
 
 #output h2 {

--- a/src/SMAPI.Web/wwwroot/Content/css/log-parser.css
+++ b/src/SMAPI.Web/wwwroot/Content/css/log-parser.css
@@ -13,6 +13,9 @@ caption {
 #output {
     padding: 10px;
     overflow: auto;
+    z-index: 1;
+    background: #fff;
+    position: relative;
 }
 
 #output h2 {

--- a/src/SMAPI.Web/wwwroot/Content/css/main.css
+++ b/src/SMAPI.Web/wwwroot/Content/css/main.css
@@ -72,6 +72,7 @@ a {
     color: #666;
 }
 
+#quickNav h4,
 #sidebar h4 {
     margin: 1.5em 0 0.2em 0;
     width: 10em;
@@ -80,11 +81,13 @@ a {
     font-weight: normal;
 }
 
+#quickNav a,
 #sidebar a {
     color: #77B;
     border: 0;
 }
 
+#quickNav ul, #quickNav li,
 #sidebar ul, #sidebar li {
     margin: 0;
     padding: 0;
@@ -93,9 +96,28 @@ a {
     color: #888;
 }
 
+#quickNav li,
 #sidebar li {
     margin-left: 1em;
 }
+
+/* quick navigation */
+
+#quickNav {
+    position: fixed;
+    left: 8px;
+    bottom: 3em;
+    width: 12em;
+    color: #666;
+}
+
+@media (max-height: 400px) {
+    #quickNav {
+        position: unset;
+        width: auto;
+    }
+}
+
 
 /* footer */
 #footer {
@@ -111,9 +133,14 @@ a {
 
 /* mobile fixes */
 @media (min-width: 1020px) and (max-width: 1199px) {
+    #quickNav,
     #sidebar {
         width: 7em;
         background: none;
+    }
+
+    #quickNav h4 {
+        width: unset;
     }
 
     #content-column {
@@ -137,5 +164,10 @@ a {
         position: inherit;
         top: inherit;
         left: inherit;
+    }
+
+    #quickNav {
+        position: unset;
+        width: auto;
     }
 }

--- a/src/SMAPI.Web/wwwroot/Content/css/main.css
+++ b/src/SMAPI.Web/wwwroot/Content/css/main.css
@@ -72,7 +72,6 @@ a {
     color: #666;
 }
 
-#quickNav h4,
 #sidebar h4 {
     margin: 1.5em 0 0.2em 0;
     width: 10em;
@@ -81,13 +80,11 @@ a {
     font-weight: normal;
 }
 
-#quickNav a,
 #sidebar a {
     color: #77B;
     border: 0;
 }
 
-#quickNav ul, #quickNav li,
 #sidebar ul, #sidebar li {
     margin: 0;
     padding: 0;
@@ -96,7 +93,6 @@ a {
     color: #888;
 }
 
-#quickNav li,
 #sidebar li {
     margin-left: 1em;
 }
@@ -105,10 +101,8 @@ a {
 
 #quickNav {
     position: fixed;
-    left: 8px;
     bottom: 3em;
     width: 12em;
-    color: #666;
 }
 
 @media (max-height: 400px) {


### PR DESCRIPTION
Hello, I'm back again!

As discussed in Discord, the message showing users how many messages there are in total was a bit unclear. I've updated the code to now count messages in collapsed sections, so the number of messages doesn't change regardless of if sections are collapsed or not. Additionally, it always uses the `showing X to Y of Z messages (total: Q)` format no matter if there are multiple pages or not.

Finally, and perhaps more important than the other changes, this also saves filter state into the URL so that people can link to a log with filtering already applied. Visible mods, log levels, and sections as well as filter text and flags are all saved to the URL along with the current page.

By default, URLs are left alone so you just have the usual `/log/d0bb9309c6ac4904a9387d1c3d569998` (as an example). Once users toggle a filter, that filter is added to the URL. Pagination parameters are also always added to the URL at that time.

For example, if a user filters the log to only show a few specific mods, they might end up with a URL like `/log/d0bb9309c6ac4904a9387d1c3d569998?Page=1&PerPage=1000&Mods=A0AAAAAAAAAAAAAAAAAAAAAAAAAA` where `Mods` is a base-64 encoded bitmap of enabled mods. Note that this particular example string is rather long because the log I'm testing with has 162 filterable mods.

Combine *all* the possible filters and you'd end up with a URL like `/log/d0bb9309c6ac4904a9387d1c3d569998?Page=1&PerPage=1000&Mods=A0AAAAAAAAAAAAAAAAAAAAAAAAAA&Levels=fQ--&Filter=test&FilterMode=AQ--`  as a worst case scenario.

Parameters are only added if the user's filter state does not match the default filter state of the page.