### PR TITLE
[Website] Improve regex safety for the log viewer

### DIFF
--- a/src/SMAPI.Web/Views/LogParser/Index.cshtml
+++ b/src/SMAPI.Web/Views/LogParser/Index.cshtml
@@ -406,6 +406,12 @@ else if (log?.IsValid == true)
                             <span role="button" v-bind:class="{ active: !filterInsensitive }" v-on:click="toggleFilterInsensitive" title="Match exact capitalization only.">aA</span>
                             <span role="button" v-bind:class="{ active: filterUseWord, 'whole-word': true }" v-on:click="toggleFilterWord" title="Match whole word only."><i>“ ”</i></span>
                             <span role="button" v-bind:class="{ active: shouldHighlight }" v-on:click="toggleHighlight" title="Highlight matches in the log text.">HL</span>
+                            <div
+                                v-if="filterError"
+                                class="filter-error"
+                            >
+                                {{ filterError }}
+                            </div>
                         </div>
                         <filter-stats
                             v-bind:start="start"

--- a/src/SMAPI.Web/wwwroot/Content/css/log-parser.css
+++ b/src/SMAPI.Web/wwwroot/Content/css/log-parser.css
@@ -187,6 +187,11 @@ table caption {
     margin-top: 0.5em;
 }
 
+#filters .filter-error {
+    color: #880000;
+}
+
+#filters .filter-error,
 #filters .stats {
     margin-top: 0.5em;
     font-size: 0.75em;
@@ -210,7 +215,7 @@ table caption {
 
 @media (max-width: 1019px) {
     #filters:not(.sticky) {
-        width: calc(100vw - 3em);
+        width: calc(100vw - 5em);
     }
 
     #filters {


### PR DESCRIPTION
A few small changes:

* Display an error message to the user if their regular expression is invalid.
* Add a safety check to message highlighting to avoid infinite loops when a zero-length match happens.
* Wrap the user's input in a non-capturing group when `Match whole word` is enabled to better handle alternates.
* Adjust the width of the filter bar on certain window sizes to hopefully prevent pagination from going slightly off screen.

Here's a screenshot of the error message display in action. It's just showing the raw message from the error thrown by `new RegExp(...)`:

![image](https://user-images.githubusercontent.com/41554123/163686250-d605afe8-152b-4581-8ea8-e87c9796f92b.png)
