### PR TITLE
Various optimizations in ModContentManager

### DIFF
--- a/src/SMAPI/Framework/ContentManagers/ModContentManager.cs
+++ b/src/SMAPI/Framework/ContentManagers/ModContentManager.cs
@@ -429,7 +429,7 @@ namespace StardewModdingAPI.Framework.ContentManagers
             FileInfo file = this.FileLookup.GetFile(path);
 
             // try with default image extensions
-            if (file.Exists || !typeof(Texture2D).IsAssignableFrom(typeof(T)) || ModContentManager.LocalTilesheetExtensions.Contains(file.Extension))
+            if (file.Exists || !typeof(Texture2D).IsAssignableFrom(typeof(T)) || ModContentManager.LocalTilesheetExtensions.Contains(file.Extension, StringComparer.OrdinalIgnoreCase))
                 return file;
 
             foreach (string extension in ModContentManager.LocalTilesheetExtensions)


### PR DESCRIPTION
Changed LocalTilesheetExtensions into an array.
Marked 'CreateTemporary' as 'Obsolete' which is conventional for methods that only throw.
Moved the type validation logic into its own method as it's largely shared for each loader.
Changed allocators to use `GC.AllocateUninitializedArray`, as the data does not need to be initialized.
Changed `LoadRawImageData` to use a `ValueTuple` return instead of returning with multiple `out`s, which is bad practice.
Preferred rethrowing handlers rather than exception filters (which generate bizarre and _very difficult to patch_ code).
Marked GetLoadError as debugger step through and hidden, as it's just an exception generator.
Marked PremultiplyTransparency, GetContentKeyForTilesheetImageSource, and LoadRawImageData as static as they have no dependency on instance data (nor should they).
Fixed `.xnb` extension search to properly use OrdinalIgnoreCase.