### PR TITLE
Search assembly directory for dependencies

### DIFF
--- a/src/SMAPI/Constants.cs
+++ b/src/SMAPI/Constants.cs
@@ -244,8 +244,8 @@ namespace StardewModdingAPI
         internal static void ConfigureAssemblyResolver(AssemblyDefinitionResolver resolver)
         {
             // add search paths
-            resolver.AddSearchDirectory(Constants.GamePath);
-            resolver.AddSearchDirectory(Constants.InternalFilesPath);
+            resolver.TryAddSearchDirectory(Constants.GamePath);
+            resolver.TryAddSearchDirectory(Constants.InternalFilesPath);
 
             // add SMAPI explicitly
             // Normally this would be handled automatically by the search paths, but for some reason there's a specific

--- a/src/SMAPI/Framework/ModLoading/AssemblyLoader.cs
+++ b/src/SMAPI/Framework/ModLoading/AssemblyLoader.cs
@@ -267,11 +267,8 @@ namespace StardewModdingAPI.Framework.ModLoading
             // add the assembly's directory temporarily if needed
             // this is needed by F# mods which bundle FSharp.Core.dll, for example
             string? temporarySearchDir = null;
-            if (file.DirectoryName is not null && !this.AssemblyDefinitionResolver.GetSearchDirectories().Contains(file.DirectoryName))
-            {
-                this.AssemblyDefinitionResolver.AddSearchDirectory(file.DirectoryName);
+            if (this.AssemblyDefinitionResolver.TryAddSearchDirectory(file.DirectoryName))
                 temporarySearchDir = file.DirectoryName;
-            }
 
             // read assembly
             AssemblyDefinition assembly;


### PR DESCRIPTION
Adds the assembly's directory to the searched paths when loading an assembly's dependencies. Previously, only the game paths and SMAPI internal files path were searched. With this change, SMAPI mod folders will also be searched, for example.

This is necessary for F# mods that want to bundle their version of `FSharp.Core.dll`. Without this change, F# mods can still be created, but the user needs to copy `FSharp.Core.dll` into their game directory, otherwise Mono.Cecil will throw an exception when reading the mod's assembly because it can't find the F# core library.