### PR TITLE
Add condition to DebugType to allow for overriding

### DIFF
--- a/src/SMAPI.ModBuildConfig/build/smapi.targets
+++ b/src/SMAPI.ModBuildConfig/build/smapi.targets
@@ -9,7 +9,7 @@
   **********************************************-->
   <PropertyGroup>
     <!-- include PDB file by default to enable line numbers in stack traces -->
-    <DebugType>pdbonly</DebugType>
+    <DebugType Condition="'$(DebugType)' == ''">pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
 
     <!-- don't create the 'refs' folder (which isn't useful for mods) -->


### PR DESCRIPTION
As it currently stands there is no way of building a Stardew mod using the ModBuildConfig package without using the windows pdb debug format.  This change adds the same sort of condition to many of the other properties so that the mod's properties will take precedence yet will still default to `pdbonly` .