### PR TITLE
Add error message for invalid PNG

### DIFF
--- a/src/SMAPI/Framework/ContentManagers/ModContentManager.cs
+++ b/src/SMAPI/Framework/ContentManagers/ModContentManager.cs
@@ -254,6 +254,8 @@ namespace StardewModdingAPI.Framework.ContentManagers
             {
                 using FileStream stream = File.OpenRead(file.FullName);
                 using SKBitmap bitmap = SKBitmap.Decode(stream);
+                if (bitmap is null)
+                    throw new InvalidDataException("{file.FullName} appears not to be a valid image file.");
                 rawPixels = SKPMColor.PreMultiply(bitmap.Pixels);
                 width = bitmap.Width;
                 height = bitmap.Height;

--- a/src/SMAPI/Framework/ContentManagers/ModContentManager.cs
+++ b/src/SMAPI/Framework/ContentManagers/ModContentManager.cs
@@ -254,8 +254,10 @@ namespace StardewModdingAPI.Framework.ContentManagers
             {
                 using FileStream stream = File.OpenRead(file.FullName);
                 using SKBitmap bitmap = SKBitmap.Decode(stream);
+
                 if (bitmap is null)
-                    throw new InvalidDataException("{file.FullName} appears not to be a valid image file.");
+                    throw new InvalidDataException($"Failed to load {file.FullName}. This doesn't seem to be a valid PNG image.");
+
                 rawPixels = SKPMColor.PreMultiply(bitmap.Pixels);
                 width = bitmap.Width;
                 height = bitmap.Height;


### PR DESCRIPTION
When SKBitmap.Decode encounters an invalid PNG, it simply returns null, leading to not-very-comprehensible error messages ([like so](https://smapi.io/log/ab3b1db5e175415f95ea27b8dbf252c3).) This just aims to make that error message less confusing.