### PR TITLE
Fix ComparableListWatcher not removing items in zero case

### DIFF
--- a/src/SMAPI/Framework/StateTracking/FieldWatchers/ComparableListWatcher.cs
+++ b/src/SMAPI/Framework/StateTracking/FieldWatchers/ComparableListWatcher.cs
@@ -63,7 +63,7 @@ namespace StardewModdingAPI.Framework.StateTracking.FieldWatchers
             {
                 if (this.LastValues.Count > 0)
                 {
-                    this.AddedImpl.AddRange(this.LastValues);
+                    this.RemovedImpl.AddRange(this.LastValues);
                     this.LastValues.Clear();
                 }
                 return;


### PR DESCRIPTION
The special zero case in ComparableListWatcher was bugged in that instead of marking items to be removed, items were marked to be added.

When the Watcher's items would be cleared, it would forever hold onto the instances preventing them from being garbage collected.