### PR TITLE
Ignore more file extensions when scanning for mods

### DIFF
--- a/src/SMAPI.Toolkit/Framework/ModScanning/ModScanner.cs
+++ b/src/SMAPI.Toolkit/Framework/ModScanning/ModScanner.cs
@@ -45,10 +45,14 @@ namespace StardewModdingAPI.Toolkit.Framework.ModScanning
             ".png",
             ".psd",
             ".tif",
+            ".xcf", // gimp files
 
             // archives
             ".rar",
             ".zip",
+            ".7z",
+            ".tar",
+            ".tar.gz"
 
             // backup files
             ".backup",


### PR DESCRIPTION
Add a few more files to the ignored files like .7z

(watching Elizabeth slowly convince someone to delete a .7z file right now :P )