### PR TITLE
Add `IMod.GetApi(IManifest manifest)`

### DIFF
--- a/src/SMAPI/Framework/ModHelpers/ModRegistryHelper.cs
+++ b/src/SMAPI/Framework/ModHelpers/ModRegistryHelper.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using StardewModdingAPI.Framework.Reflection;
+using StardewModdingAPI.Internal;
 
 namespace StardewModdingAPI.Framework.ModHelpers
 {
@@ -15,8 +17,8 @@ namespace StardewModdingAPI.Framework.ModHelpers
         /// <summary>Encapsulates monitoring and logging for the mod.</summary>
         private readonly IMonitor Monitor;
 
-        /// <summary>The mod IDs for APIs accessed by this instanced.</summary>
-        private readonly HashSet<string> AccessedModApis = new();
+        /// <summary>The APIs accessed by this instance.</summary>
+        private readonly Dictionary<string, object?> AccessedModApis = new();
 
         /// <summary>Generates proxy classes to access mod APIs through an arbitrary interface.</summary>
         private readonly IInterfaceProxyFactory ProxyFactory;
@@ -66,11 +68,50 @@ namespace StardewModdingAPI.Framework.ModHelpers
                 return null;
             }
 
-            // get raw API
+            // get our cached API if one is available
             IModMetadata? mod = this.Registry.Get(uniqueID);
-            if (mod?.Api != null && this.AccessedModApis.Add(mod.Manifest.UniqueID))
-                this.Monitor.Log($"Accessed mod-provided API for {mod.DisplayName}.");
-            return mod?.Api;
+            if (mod == null)
+                return null;
+
+            if (this.AccessedModApis.ContainsKey(mod.Manifest.UniqueID))
+            {
+                return this.AccessedModApis[mod.Manifest.UniqueID];
+            }
+
+            object? api;
+
+            // safely request a specific API instance
+            try
+            {
+                api = mod.Mod?.GetApi(this.Mod.Manifest);
+                if (api != null && !api.GetType().IsPublic)
+                {
+                    api = null;
+                    this.Monitor.Log($"{mod.DisplayName} provided a specific API instance with a non-public type. This isn't currently supported, so the specific API won't be available to the requesting mod.", LogLevel.Warn);
+                }
+
+                if (api != null)
+                    this.Monitor.Log($"Accessed specific mod-provided API ({api.GetType().FullName}) for {mod.DisplayName}.");
+            }
+            catch (Exception ex)
+            {
+                this.Monitor.Log($"Failed loading specific mod-provided API for {mod.DisplayName}. Integrations with other mods may not work. Error: {ex.GetLogSummary()}", LogLevel.Error);
+                api = null;
+            }
+
+            // fall back to the generic API instance
+            if (api == null)
+            {
+                api = mod.Api;
+                if (api != null)
+                {
+                    this.Monitor.Log($"Accessed mod-provided API for {mod.DisplayName}.");
+                }
+            }
+
+            // cache the API instance and return it
+            this.AccessedModApis[mod.Manifest.UniqueID] = api;
+            return api;
         }
 
         /// <inheritdoc />

--- a/src/SMAPI/Framework/ModHelpers/ModRegistryHelper.cs
+++ b/src/SMAPI/Framework/ModHelpers/ModRegistryHelper.cs
@@ -85,7 +85,7 @@ namespace StardewModdingAPI.Framework.ModHelpers
                 {
                     try
                     {
-                        api = mod.Mod?.GetApi(this.Mod.Manifest);
+                        api = mod.Mod?.GetApi(this.Mod);
                         if (api != null && !api.GetType().IsPublic)
                         {
                             api = null;

--- a/src/SMAPI/Framework/SCore.cs
+++ b/src/SMAPI/Framework/SCore.cs
@@ -1779,6 +1779,11 @@ namespace StardewModdingAPI.Framework
                 {
                     this.Monitor.Log($"Failed loading mod-provided API for {metadata.DisplayName}. Integrations with other mods may not work. Error: {ex.GetLogSummary()}", LogLevel.Error);
                 }
+
+                // validate mod doesn't implement both GetApi() and GetApi(mod)
+                if (metadata.Api != null && metadata.Mod!.GetType().GetMethod(nameof(Mod.GetApi), new Type[] { typeof(IManifest) })!.DeclaringType != typeof(Mod))
+                    metadata.LogAsMod($"Mod implements both {nameof(Mod.GetApi)}() and {nameof(Mod.GetApi)}({nameof(IManifest)}), which isn't allowed. The latter will be ignored.", LogLevel.Error);
+
                 Context.HeuristicModsRunningCode.TryPop(out _);
             }
 

--- a/src/SMAPI/IMod.cs
+++ b/src/SMAPI/IMod.cs
@@ -24,14 +24,14 @@ namespace StardewModdingAPI
         void Entry(IModHelper helper);
 
         /// <summary>Get an <a href="https://stardewvalleywiki.com/Modding:Modder_Guide/APIs/Integrations">API that other mods can access</a>. This is always called after <see cref="Entry"/>, and is only called once even if multiple mods access it.</summary>
-        /// <remarks>You can implement <see cref="GetApi()"/> to provide one instance to all mods, or <see cref="GetApi(IManifest)"/> to provide a separate instance per mod. These are mutually exclusive, so you can only implement one of them.</remarks>
+        /// <remarks>You can implement <see cref="GetApi()"/> to provide one instance to all mods, or <see cref="GetApi(IModInfo)"/> to provide a separate instance per mod. These are mutually exclusive, so you can only implement one of them.</remarks>
         /// <remarks>Returns the API instance, or <c>null</c> if the mod has no API.</remarks>
         object? GetApi();
 
         /// <summary>Get an <a href="https://stardewvalleywiki.com/Modding:Modder_Guide/APIs/Integrations">API that other mods can access</a>. This is always called after <see cref="Entry"/>, and is called once per mod that accesses the API (even if they access it multiple times).</summary>
-        /// <param name="manifest">The manifest for the mod accessing the API.</param>
+        /// <param name="mod">The mod accessing the API.</param>
         /// <remarks>Returns the API instance, or <c>null</c> if the mod has no API. Note that the manifest is provided for informational purposes only, and that denying API access to specific mods is strongly discouraged and may be considered abusive.</remarks>
         /// <inheritdoc cref="GetApi()" include="/Remarks" />
-        object? GetApi(IManifest manifest);
+        object? GetApi(IModInfo mod);
     }
 }

--- a/src/SMAPI/IMod.cs
+++ b/src/SMAPI/IMod.cs
@@ -23,13 +23,15 @@ namespace StardewModdingAPI
         /// <param name="helper">Provides simplified APIs for writing mods.</param>
         void Entry(IModHelper helper);
 
-        /// <summary>Get an API that other mods can access. This is always called after <see cref="Entry"/>.</summary>
+        /// <summary>Get an <a href="https://stardewvalleywiki.com/Modding:Modder_Guide/APIs/Integrations">API that other mods can access</a>. This is always called after <see cref="Entry"/>, and is only called once even if multiple mods access it.</summary>
+        /// <remarks>You can implement <see cref="GetApi()"/> to provide one instance to all mods, or <see cref="GetApi(IManifest)"/> to provide a separate instance per mod. These are mutually exclusive, so you can only implement one of them.</remarks>
+        /// <remarks>Returns the API instance, or <c>null</c> if the mod has no API.</remarks>
         object? GetApi();
 
-        /// <summary>Get an API that a specific other mod can access. This method is called the first time the other mod calls <see cref="IModRegistry.GetApi(string)"/> for this mod.</summary>
-        /// <param name="manifest">The other mod's manifest.</param>
-        /// <returns>Returns an API for another mod, or <c>null</c> if the other mod should use the general API returned from <see cref="GetApi()"/>.</returns>
+        /// <summary>Get an <a href="https://stardewvalleywiki.com/Modding:Modder_Guide/APIs/Integrations">API that other mods can access</a>. This is always called after <see cref="Entry"/>, and is called once per mod that accesses the API (even if they access it multiple times).</summary>
+        /// <param name="manifest">The manifest for the mod accessing the API.</param>
+        /// <remarks>Returns the API instance, or <c>null</c> if the mod has no API. Note that the manifest is provided for informational purposes only, and that denying API access to specific mods is strongly discouraged and may be considered abusive.</remarks>
+        /// <inheritdoc cref="GetApi()" include="/Remarks" />
         object? GetApi(IManifest manifest);
-
     }
 }

--- a/src/SMAPI/IMod.cs
+++ b/src/SMAPI/IMod.cs
@@ -25,5 +25,11 @@ namespace StardewModdingAPI
 
         /// <summary>Get an API that other mods can access. This is always called after <see cref="Entry"/>.</summary>
         object? GetApi();
+
+        /// <summary>Get an API that a specific other mod can access. This method is called the first time the other mod calls <see cref="IModRegistry.GetApi(string)"/> for this mod.</summary>
+        /// <param name="manifest">The other mod's manifest.</param>
+        /// <returns>Returns an API for another mod, or <c>null</c> if the other mod should use the general API returned from <see cref="GetApi()"/>.</returns>
+        object? GetApi(IManifest manifest);
+
     }
 }

--- a/src/SMAPI/Mod.cs
+++ b/src/SMAPI/Mod.cs
@@ -30,6 +30,12 @@ namespace StardewModdingAPI
             return null;
         }
 
+        /// <inheritdoc />
+        public virtual object? GetApi(IManifest manifest)
+        {
+            return null;
+        }
+
         /// <summary>Release or reset unmanaged resources.</summary>
         public void Dispose()
         {

--- a/src/SMAPI/Mod.cs
+++ b/src/SMAPI/Mod.cs
@@ -31,7 +31,7 @@ namespace StardewModdingAPI
         }
 
         /// <inheritdoc />
-        public virtual object? GetApi(IManifest manifest)
+        public virtual object? GetApi(IModInfo mod)
         {
             return null;
         }


### PR DESCRIPTION
This PR, as discussed recently on Discord, adds a new method to `IMod` for getting an API instance from a mod. This new method takes the manifest of the mod requesting access to the API.

As a result of this, mods will be able to better track usage of their APIs. There is a common pattern in APIs at this time that rely on other mods providing their own manifest as the first parameter of a function call. That will become unnecessary in the future thanks to this change. (That said, providing an optional manifest when doing API calls on behalf of another mod still has value, but that's an implementation detail for specific mods to worry about.)

The changes in this PR are as follows:

1. Add the new `GetApi(IManifest manifest)` to `IMod`.
2. Add a default implementation of `GetApi(IManifest manifest)` to `Mod` that returns `null`.
3. Change `ModRegistryHelper` so that it will call the new method, and only fallback to the cached result of the existing `GetApi()` if the new method returns `null`.
4. Change `ModRegistryHelper` so that it caches API instances in a dictionary, rather than merely using a `HashSet` to track API accesses.

A couple notes for discussion:

1. What should be the nomenclature for an API instance provided specifically for another mod via `GetApi(IManifest)` versus the generic API instance returned from `GetApi()`?

I am in general not satisfied with my documentation strings and log messages as I feel they might be slightly confusing. I haven't yet thought of something better.

2. Should the call to `GetApi(IManifest)` happen within `ModRegistryHelper`, `ModMetadata`, or somewhere else?

Currently I just shoved it into `ModRegistryHelper`, but I feel like a method in `ModMetadata` might be preferred to contain the try/catch logic and `IsPublic()` check. In fact, a slight refactor of the existing access of `GetApi()` might be desired to ensure all API instances are run through the same checks in the event that new checks are added in the future.


I've tested this on my local machine with roughly 50 C# mods and haven't had any issues, including after I added support for the new `GetApi(IManifest)` to my Better Crafting mod.