### PR TITLE
Rewrite asset name comparison to stop at the first mismatch

### DIFF
--- a/src/SMAPI.Tests/Core/AssetNameTests.cs
+++ b/src/SMAPI.Tests/Core/AssetNameTests.cs
@@ -151,6 +151,12 @@ namespace SMAPI.Tests.Core
 
         // with locale codes
         [TestCase("Data/Achievements.fr-FR", "Data/Achievements", ExpectedResult = true)]
+
+        // prefix ends with path separator
+        [TestCase("Data/Events/Boop", "Data/Events/", ExpectedResult = true)]
+        [TestCase("Data/Events/Boop", "Data/Events\\", ExpectedResult = true)]
+        [TestCase("Data/Events", "Data/Events/", ExpectedResult = false)]
+        [TestCase("Data/Events", "Data/Events\\", ExpectedResult = false)]
         public bool StartsWith_SimpleCases(string mainAssetName, string prefix)
         {
             // arrange
@@ -247,7 +253,7 @@ namespace SMAPI.Tests.Core
         [TestCase("Mods/SomeMod/SomeSubdirectory", "Mods/Some", false, ExpectedResult = false)]
         [TestCase("Mods/Jasper/Data", "Mods/Jas/Image", true, ExpectedResult = false)]
         [TestCase("Mods/Jasper/Data", "Mods/Jas/Image", true, ExpectedResult = false)]
-        public bool StartsWith_SubfolderWithPartial(string mainAssetName, string otherAssetName, bool allowSubfolder)
+        public bool StartsWith_PartialMatchInPathSegment(string mainAssetName, string otherAssetName, bool allowSubfolder)
         {
             // arrange
             mainAssetName = PathUtilities.NormalizeAssetName(mainAssetName);

--- a/src/SMAPI.Tests/Core/AssetNameTests.cs
+++ b/src/SMAPI.Tests/Core/AssetNameTests.cs
@@ -245,6 +245,8 @@ namespace SMAPI.Tests.Core
 
         [TestCase("Mods/SomeMod/SomeSubdirectory", "Mods/Some", true, ExpectedResult = true)]
         [TestCase("Mods/SomeMod/SomeSubdirectory", "Mods/Some", false, ExpectedResult = false)]
+        [TestCase("Mods/Jasper/Data", "Mods/Jas/Image", true, ExpectedResult = false)]
+        [TestCase("Mods/Jasper/Data", "Mods/Jas/Image", true, ExpectedResult = false)]
         public bool StartsWith_SubfolderWithPartial(string mainAssetName, string otherAssetName, bool allowSubfolder)
         {
             // arrange

--- a/src/SMAPI.Tests/Core/AssetNameTests.cs
+++ b/src/SMAPI.Tests/Core/AssetNameTests.cs
@@ -243,6 +243,20 @@ namespace SMAPI.Tests.Core
             return result;
         }
 
+        [TestCase("Mods/SomeMod/SomeSubdirectory", "Mods/Some", true, ExpectedResult = true)]
+        [TestCase("Mods/SomeMod/SomeSubdirectory", "Mods/Some", false, ExpectedResult = false)]
+        public bool StartsWith_SubfolderWithPartial(string mainAssetName, string otherAssetName, bool allowSubfolder)
+        {
+            // arrange
+            mainAssetName = PathUtilities.NormalizeAssetName(mainAssetName);
+
+            // act
+            AssetName name = AssetName.Parse(mainAssetName, _ => null);
+
+            // assert value
+            return name.StartsWith(otherAssetName, allowPartialWord: true, allowSubfolder: allowSubfolder);
+        }
+
 
         /****
         ** GetHashCode

--- a/src/SMAPI.Tests/SMAPI.Tests.csproj
+++ b/src/SMAPI.Tests/SMAPI.Tests.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SMAPI/Framework/Content/AssetName.cs
+++ b/src/SMAPI/Framework/Content/AssetName.cs
@@ -139,21 +139,19 @@ namespace StardewModdingAPI.Framework.Content
             if (prefix is null)
                 return false;
 
+            // get initial values
             ReadOnlySpan<char> trimmed = prefix.AsSpan().Trim();
+            if (trimmed.Length == 0)
+                return true;
+            ReadOnlySpan<char> pathSeparators = new(ToolkitPathUtilities.PossiblePathSeparators); // just to simplify calling other span APIs
 
-            // just because most ReadOnlySpan/Span APIs expect a ReadOnlySpan/Span, easier to read.
-            ReadOnlySpan<char> pathSeparators = new(ToolkitPathUtilities.PossiblePathSeparators);
-
-            // asset keys can't have a leading slash, but AssetPathYielder won't yield that.
+            // asset keys can't have a leading slash, but AssetPathYielder will trim them
             if (pathSeparators.Contains(trimmed[0]))
                 return false;
 
-            if (trimmed.Length == 0)
-                return true;
-
+            // compare segments
             AssetNamePartEnumerator curParts = new(this.Name);
             AssetNamePartEnumerator prefixParts = new(trimmed);
-
             while (true)
             {
                 bool prefixHasMore = prefixParts.MoveNext();

--- a/src/SMAPI/Framework/Content/AssetName.cs
+++ b/src/SMAPI/Framework/Content/AssetName.cs
@@ -162,8 +162,8 @@ namespace StardewModdingAPI.Framework.Content
                     if (prefixHasMore)
                         return false;
 
-                    // possible match: all prefix segments matched
-                    return allowSubfolder || !curParts.Remainder.Contains(pathSeparators, StringComparison.Ordinal);
+                    // possible match: all prefix segments matched.
+                    return allowSubfolder || (pathSeparators.Contains(trimmed[^1]) ? curParts.Remainder.Length == 0 : curParts.Current.Length == 0);
                 }
 
                 // match: previous segments matched exactly and both reached the end
@@ -192,7 +192,7 @@ namespace StardewModdingAPI.Framework.Content
                         return false;
 
                     // possible match
-                    return allowSubfolder || !curParts.Remainder.Contains(pathSeparators, StringComparison.Ordinal);
+                    return allowSubfolder || (pathSeparators.Contains(trimmed[^1]) ? curParts.Remainder.IndexOfAny(ToolkitPathUtilities.PossiblePathSeparators) < 0 : curParts.Remainder.Length == 0);
                 }
             }
         }
@@ -203,7 +203,7 @@ namespace StardewModdingAPI.Framework.Content
             if (assetFolder is null)
                 return false;
 
-            return this.StartsWith(assetFolder + "/", allowPartialWord: false, allowSubfolder: false);
+            return this.StartsWith(assetFolder + ToolkitPathUtilities.PreferredPathSeparator, allowPartialWord: false, allowSubfolder: false);
         }
 
         /// <inheritdoc />

--- a/src/SMAPI/Framework/Content/AssetName.cs
+++ b/src/SMAPI/Framework/Content/AssetName.cs
@@ -179,6 +179,10 @@ namespace StardewModdingAPI.Framework.Content
                 }
                 else
                 {
+                    // mismatch: prefix has more beyond this, and this segment isn't an exact match
+                    if (prefixParts.Remainder.Length != 0)
+                        return false;
+
                     // mismatch: cur segment doesn't start with prefix
                     if (!curParts.Current.StartsWith(prefixParts.Current, StringComparison.OrdinalIgnoreCase))
                         return false;

--- a/src/SMAPI/Framework/Content/AssetName.cs
+++ b/src/SMAPI/Framework/Content/AssetName.cs
@@ -97,7 +97,7 @@ namespace StardewModdingAPI.Framework.Content
                 return false;
 
             AssetNamePartEnumerator curParts = new(useBaseName ? this.BaseName : this.Name);
-            AssetNamePartEnumerator otherParts = new(assetName);
+            AssetNamePartEnumerator otherParts = new(assetName.AsSpan().Trim());
 
             while (true)
             {

--- a/src/SMAPI/Utilities/AssetPathUtilities/AssetNamePartEnumerator.cs
+++ b/src/SMAPI/Utilities/AssetPathUtilities/AssetNamePartEnumerator.cs
@@ -1,5 +1,4 @@
 using System;
-
 using ToolkitPathUtilities = StardewModdingAPI.Toolkit.Utilities.PathUtilities;
 
 namespace StardewModdingAPI.Utilities.AssetPathUtilities;
@@ -7,23 +6,23 @@ namespace StardewModdingAPI.Utilities.AssetPathUtilities;
 /// <summary>
 /// A helper class that yields out each bit of an asset path
 /// </summary>
-internal ref struct AssetPartYielder
+internal ref struct AssetNamePartEnumerator
 {
-    private ReadOnlySpan<char> remainder;
+    private ReadOnlySpan<char> RemainderImpl;
 
     /// <summary>
     /// Construct an instance.
     /// </summary>
     /// <param name="assetName">The asset name.</param>
-    internal AssetPartYielder(ReadOnlySpan<char> assetName)
+    internal AssetNamePartEnumerator(ReadOnlySpan<char> assetName)
     {
-        this.remainder = AssetPartYielder.TrimLeadingPathSeperators(assetName);
+        this.RemainderImpl = AssetNamePartEnumerator.TrimLeadingPathSeparators(assetName);
     }
 
     /// <summary>
     /// The remainder of the assetName (that hasn't been yielded out yet.)
     /// </summary>
-    internal ReadOnlySpan<char> Remainder => this.remainder;
+    internal ReadOnlySpan<char> Remainder => this.RemainderImpl;
 
     /// <summary>
     /// The current segment.
@@ -31,7 +30,7 @@ internal ref struct AssetPartYielder
     public ReadOnlySpan<char> Current { get; private set; } = default;
 
     // this is just so it can be used in a foreach loop.
-    public AssetPartYielder GetEnumerator() => this;
+    public AssetNamePartEnumerator GetEnumerator() => this;
 
     /// <summary>
     /// Moves the enumerator to the next element.
@@ -39,28 +38,28 @@ internal ref struct AssetPartYielder
     /// <returns>True if there is a new</returns>
     public bool MoveNext()
     {
-        if (this.remainder.Length == 0)
+        if (this.RemainderImpl.Length == 0)
         {
             return false;
         }
 
-        int index = this.remainder.IndexOfAny(ToolkitPathUtilities.PossiblePathSeparators);
+        int index = this.RemainderImpl.IndexOfAny(ToolkitPathUtilities.PossiblePathSeparators);
 
-        // no more seperator characters found, I'm done.
+        // no more separator characters found, I'm done.
         if (index < 0)
         {
-            this.Current = this.remainder;
-            this.remainder = ReadOnlySpan<char>.Empty;
+            this.Current = this.RemainderImpl;
+            this.RemainderImpl = ReadOnlySpan<char>.Empty;
             return true;
         }
 
-        // Yield the next seperate character bit
-        this.Current = this.remainder[..index];
-        this.remainder = AssetPartYielder.TrimLeadingPathSeperators(this.remainder[(index + 1)..]);
+        // Yield the next separate character bit
+        this.Current = this.RemainderImpl[..index];
+        this.RemainderImpl = AssetNamePartEnumerator.TrimLeadingPathSeparators(this.RemainderImpl[(index + 1)..]);
         return true;
     }
 
-    private static ReadOnlySpan<char> TrimLeadingPathSeperators(ReadOnlySpan<char> span)
+    private static ReadOnlySpan<char> TrimLeadingPathSeparators(ReadOnlySpan<char> span)
     {
         return span.TrimStart(new ReadOnlySpan<char>(ToolkitPathUtilities.PossiblePathSeparators));
     }

--- a/src/SMAPI/Utilities/AssetPathUtilities/AssetPartYielder.cs
+++ b/src/SMAPI/Utilities/AssetPathUtilities/AssetPartYielder.cs
@@ -1,0 +1,67 @@
+using System;
+
+using ToolkitPathUtilities = StardewModdingAPI.Toolkit.Utilities.PathUtilities;
+
+namespace StardewModdingAPI.Utilities.AssetPathUtilities;
+
+/// <summary>
+/// A helper class that yields out each bit of an asset path
+/// </summary>
+internal ref struct AssetPartYielder
+{
+    private ReadOnlySpan<char> remainder;
+
+    /// <summary>
+    /// Construct an instance.
+    /// </summary>
+    /// <param name="assetName">The asset name.</param>
+    internal AssetPartYielder(ReadOnlySpan<char> assetName)
+    {
+        this.remainder = AssetPartYielder.TrimLeadingPathSeperators(assetName);
+    }
+
+    /// <summary>
+    /// The remainder of the assetName (that hasn't been yielded out yet.)
+    /// </summary>
+    internal ReadOnlySpan<char> Remainder => this.remainder;
+
+    /// <summary>
+    /// The current segment.
+    /// </summary>
+    public ReadOnlySpan<char> Current { get; private set; } = default;
+
+    // this is just so it can be used in a foreach loop.
+    public AssetPartYielder GetEnumerator() => this;
+
+    /// <summary>
+    /// Moves the enumerator to the next element.
+    /// </summary>
+    /// <returns>True if there is a new</returns>
+    public bool MoveNext()
+    {
+        if (this.remainder.Length == 0)
+        {
+            return false;
+        }
+
+        int index = this.remainder.IndexOfAny(ToolkitPathUtilities.PossiblePathSeparators);
+
+        // no more seperator characters found, I'm done.
+        if (index < 0)
+        {
+            this.Current = this.remainder;
+            this.remainder = ReadOnlySpan<char>.Empty;
+            return true;
+        }
+
+        // Yield the next seperate character bit
+        this.Current = this.remainder[..index];
+        this.remainder = AssetPartYielder.TrimLeadingPathSeperators(this.remainder[(index + 1)..]);
+        return true;
+    }
+
+    private static ReadOnlySpan<char> TrimLeadingPathSeperators(ReadOnlySpan<char> span)
+    {
+        return span.TrimStart(new ReadOnlySpan<char>(ToolkitPathUtilities.PossiblePathSeparators));
+    }
+}


### PR DESCRIPTION
Hi Pathos!

This PR just makes `AssetName.IsEquivalentTo` and `AssetName.StartsWith` avoid splitting + re-forming strings all the time. Instead, it now checks each segment of each path against the matching segment in the other path.

Couple of things I should probably apologize for:
1. I just stuck AssetPartYielder in a random namespace, I don't really know where it should go best.
2. I hope the comments made sense. I tried to insert comments where it made sense, but let me know if anything's unclear.