### PR TITLE
Add detailed manifest validation errors at build time

### DIFF
--- a/src/SMAPI.ModBuildConfig/DeployModTask.cs
+++ b/src/SMAPI.ModBuildConfig/DeployModTask.cs
@@ -85,33 +85,30 @@ namespace StardewModdingAPI.ModBuildConfig
                 return true;
 
             // validate the manifest file
-            Manifest manifest;
+            IManifest manifest;
             {
-                // check if manifest file exists
-                FileInfo manifestFile = new(Path.Combine(this.ProjectDir, "manifest.json"));
-                if (!manifestFile.Exists)
-                {
-                    this.Log.LogError("[mod build package] The mod does not have a manifest.json file.");
-                    return false;
-                }
-
-                // check if the json is valid
                 try
                 {
-                    new JsonHelper().ReadJsonFileIfExists(manifestFile.FullName, out manifest);
+                    string manifestPath = Path.Combine(this.ProjectDir, "manifest.json");
+                    if (!new JsonHelper().ReadJsonFileIfExists(manifestPath, out Manifest rawManifest))
+                    {
+                        this.Log.LogError("[mod build package] The mod's manifest.json file doesn't exist.");
+                        return false;
+                    }
+                    manifest = rawManifest;
                 }
                 catch (JsonReaderException ex)
                 {
                     // log the inner exception, otherwise the message will be generic
                     Exception exToShow = ex.InnerException ?? ex;
-                    this.Log.LogError($"[mod build package] Failed to parse manifest.json: {exToShow.Message}");
+                    this.Log.LogError($"[mod build package] The mod's manifest.json file isn't valid JSON: {exToShow.Message}");
                     return false;
                 }
 
-                // validate the manifest's fields
-                if (!ManifestValidator.TryValidate(manifest, out string error))
+                // validate manifest fields
+                if (!ManifestValidator.TryValidateFields(manifest, out string error))
                 {
-                    this.Log.LogError($"[mod build package] The mod manifest is invalid: {error}");
+                    this.Log.LogError($"[mod build package] The mod's manifest.json file is invalid: {error}");
                     return false;
                 }
             }

--- a/src/SMAPI.ModBuildConfig/DeployModTask.cs
+++ b/src/SMAPI.ModBuildConfig/DeployModTask.cs
@@ -9,6 +9,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Newtonsoft.Json;
 using StardewModdingAPI.ModBuildConfig.Framework;
+using StardewModdingAPI.Toolkit.Framework;
 using StardewModdingAPI.Toolkit.Serialization;
 using StardewModdingAPI.Toolkit.Serialization.Models;
 using StardewModdingAPI.Toolkit.Utilities;
@@ -91,7 +92,8 @@ namespace StardewModdingAPI.ModBuildConfig
             try
             {
                 new JsonHelper().ReadJsonFileIfExists(manifestFile.FullName, out manifest);
-            } catch (JsonReaderException ex)
+            }
+            catch (JsonReaderException ex)
             {
                 // log the inner exception, otherwise the message will be generic
                 Exception exToShow = ex.InnerException ?? ex;
@@ -100,7 +102,7 @@ namespace StardewModdingAPI.ModBuildConfig
             }
 
             // validate the manifest's fields
-            if (!manifest.TryValidate(out string error))
+            if (!ManifestValidator.TryValidate(manifest, out string error))
             {
                 this.Log.LogError($"[mod build package] The mod manifest is invalid: {error}");
                 return false;

--- a/src/SMAPI.ModBuildConfig/Framework/ModFileManager.cs
+++ b/src/SMAPI.ModBuildConfig/Framework/ModFileManager.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
-using StardewModdingAPI.Toolkit.Serialization;
-using StardewModdingAPI.Toolkit.Serialization.Models;
 using StardewModdingAPI.Toolkit.Utilities;
 
 namespace StardewModdingAPI.ModBuildConfig.Framework
@@ -111,16 +109,6 @@ namespace StardewModdingAPI.ModBuildConfig.Framework
         public IDictionary<string, FileInfo> GetFiles()
         {
             return new Dictionary<string, FileInfo>(this.Files, StringComparer.OrdinalIgnoreCase);
-        }
-
-        /// <summary>Get a semantic version from the mod manifest.</summary>
-        /// <exception cref="UserErrorException">The manifest is missing or invalid.</exception>
-        public string GetManifestVersion()
-        {
-            if (!this.Files.TryGetValue(this.ManifestFileName, out FileInfo manifestFile) || !new JsonHelper().ReadJsonFileIfExists(manifestFile.FullName, out Manifest manifest))
-                throw new InvalidOperationException($"The mod does not have a {this.ManifestFileName} file."); // shouldn't happen since we validate in constructor
-
-            return manifest.Version.ToString();
         }
 
 

--- a/src/SMAPI.Toolkit/Framework/ManifestValidator.cs
+++ b/src/SMAPI.Toolkit/Framework/ManifestValidator.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using StardewModdingAPI.Toolkit.Utilities;
+
+namespace StardewModdingAPI.Toolkit.Framework
+{
+    /// <summary>Validates manifest fields.</summary>
+    public static class ManifestValidator
+    {
+        /// <summary>Try to validate a manifest's fields. Fails if any invalid field is found.</summary>
+        /// <param name="manifest">The manifest to validate.</param>
+        /// <param name="error">The error message to display to the user.</param>
+        /// <returns>Returns whether the manifest was validated successfully.</returns>
+        public static bool TryValidate(IManifest manifest, out string error)
+        {
+            // validate DLL / content pack fields
+            bool hasDll = !string.IsNullOrWhiteSpace(manifest.EntryDll);
+            bool isContentPack = manifest.ContentPackFor != null;
+
+            // validate field presence
+            if (!hasDll && !isContentPack)
+            {
+                error = $"manifest has no {nameof(IManifest.EntryDll)} or {nameof(IManifest.ContentPackFor)} field; must specify one.";
+                return false;
+            }
+            if (hasDll && isContentPack)
+            {
+                error = $"manifest sets both {nameof(IManifest.EntryDll)} and {nameof(IManifest.ContentPackFor)}, which are mutually exclusive.";
+                return false;
+            }
+
+            // validate DLL filename format
+            if (hasDll && manifest.EntryDll!.Intersect(Path.GetInvalidFileNameChars()).Any())
+            {
+                error = $"manifest has invalid filename '{manifest.EntryDll}' for the EntryDLL field.";
+                return false;
+            }
+
+            // validate content pack ID
+            else if (isContentPack && string.IsNullOrWhiteSpace(manifest.ContentPackFor!.UniqueID))
+            {
+                error = $"manifest declares {nameof(IManifest.ContentPackFor)} without its required {nameof(IManifestContentPackFor.UniqueID)} field.";
+                return false;
+            }
+
+            // validate required fields
+            {
+                List<string> missingFields = new List<string>(3);
+
+                if (string.IsNullOrWhiteSpace(manifest.Name))
+                    missingFields.Add(nameof(IManifest.Name));
+                if (manifest.Version == null || manifest.Version.ToString() == "0.0.0")
+                    missingFields.Add(nameof(IManifest.Version));
+                if (string.IsNullOrWhiteSpace(manifest.UniqueID))
+                    missingFields.Add(nameof(IManifest.UniqueID));
+
+                if (missingFields.Any())
+                {
+                    error = $"manifest is missing required fields ({string.Join(", ", missingFields)}).";
+                    return false;
+                }
+            }
+
+            // validate ID format
+            if (!PathUtilities.IsSlug(manifest.UniqueID))
+            {
+                error = "manifest specifies an invalid ID (IDs must only contain letters, numbers, underscores, periods, or hyphens).";
+                return false;
+            }
+
+            // validate dependencies
+            foreach (IManifestDependency? dependency in manifest.Dependencies)
+            {
+                // null dependency
+                if (dependency == null)
+                {
+                    error = $"manifest has a null entry under {nameof(IManifest.Dependencies)}.";
+                    return false;
+                }
+
+                // missing ID
+                if (string.IsNullOrWhiteSpace(dependency.UniqueID))
+                {
+                    error = $"manifest has a {nameof(IManifest.Dependencies)} entry with no {nameof(IManifestDependency.UniqueID)} field.";
+                    return false;
+                }
+
+                // invalid ID
+                if (!PathUtilities.IsSlug(dependency.UniqueID))
+                {
+                    error = $"manifest has a {nameof(IManifest.Dependencies)} entry with an invalid {nameof(IManifestDependency.UniqueID)} field (IDs must only contain letters, numbers, underscores, periods, or hyphens).";
+                    return false;
+                }
+            }
+
+            error = "";
+            return true;
+        }
+    }
+}

--- a/src/SMAPI.Toolkit/Framework/ManifestValidator.cs
+++ b/src/SMAPI.Toolkit/Framework/ManifestValidator.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using StardewModdingAPI.Toolkit.Utilities;
@@ -8,40 +9,47 @@ namespace StardewModdingAPI.Toolkit.Framework
     /// <summary>Validates manifest fields.</summary>
     public static class ManifestValidator
     {
-        /// <summary>Try to validate a manifest's fields. Fails if any invalid field is found.</summary>
+        /// <summary>Validate a manifest's fields.</summary>
         /// <param name="manifest">The manifest to validate.</param>
-        /// <param name="error">The error message to display to the user.</param>
-        /// <returns>Returns whether the manifest was validated successfully.</returns>
-        public static bool TryValidate(IManifest manifest, out string error)
+        /// <param name="error">The error message indicating why validation failed, if applicable.</param>
+        /// <returns>Returns whether all manifest fields validated successfully.</returns>
+        [SuppressMessage("ReSharper", "ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract", Justification = "This is the method that ensures those annotations are respected.")]
+        public static bool TryValidateFields(IManifest manifest, out string error)
         {
-            // validate DLL / content pack fields
+            //
+            // Note: SMAPI assumes that it can grammatically append the returned sentence in the
+            // form "failed loading <mod> because its <error>". Any errors returned should be valid
+            // in that format, unless the SMAPI call is adjusted accordingly.
+            //
+
             bool hasDll = !string.IsNullOrWhiteSpace(manifest.EntryDll);
             bool isContentPack = manifest.ContentPackFor != null;
 
-            // validate field presence
-            if (!hasDll && !isContentPack)
+            // validate use of EntryDll vs ContentPackFor fields
+            if (hasDll == isContentPack)
             {
-                error = $"manifest has no {nameof(IManifest.EntryDll)} or {nameof(IManifest.ContentPackFor)} field; must specify one.";
-                return false;
-            }
-            if (hasDll && isContentPack)
-            {
-                error = $"manifest sets both {nameof(IManifest.EntryDll)} and {nameof(IManifest.ContentPackFor)}, which are mutually exclusive.";
+                error = hasDll
+                    ? $"manifest sets both {nameof(IManifest.EntryDll)} and {nameof(IManifest.ContentPackFor)}, which are mutually exclusive."
+                    : $"manifest has no {nameof(IManifest.EntryDll)} or {nameof(IManifest.ContentPackFor)} field; must specify one.";
                 return false;
             }
 
-            // validate DLL filename format
-            if (hasDll && manifest.EntryDll!.Intersect(Path.GetInvalidFileNameChars()).Any())
+            // validate EntryDll/ContentPackFor format
+            if (hasDll)
             {
-                error = $"manifest has invalid filename '{manifest.EntryDll}' for the EntryDLL field.";
-                return false;
+                if (manifest.EntryDll!.Intersect(Path.GetInvalidFileNameChars()).Any())
+                {
+                    error = $"manifest has invalid filename '{manifest.EntryDll}' for the {nameof(IManifest.EntryDll)} field.";
+                    return false;
+                }
             }
-
-            // validate content pack ID
-            else if (isContentPack && string.IsNullOrWhiteSpace(manifest.ContentPackFor!.UniqueID))
+            else
             {
-                error = $"manifest declares {nameof(IManifest.ContentPackFor)} without its required {nameof(IManifestContentPackFor.UniqueID)} field.";
-                return false;
+                if (string.IsNullOrWhiteSpace(manifest.ContentPackFor!.UniqueID))
+                {
+                    error = $"manifest declares {nameof(IManifest.ContentPackFor)} without its required {nameof(IManifestContentPackFor.UniqueID)} field.";
+                    return false;
+                }
             }
 
             // validate required fields
@@ -69,24 +77,21 @@ namespace StardewModdingAPI.Toolkit.Framework
                 return false;
             }
 
-            // validate dependencies
+            // validate dependency format
             foreach (IManifestDependency? dependency in manifest.Dependencies)
             {
-                // null dependency
                 if (dependency == null)
                 {
                     error = $"manifest has a null entry under {nameof(IManifest.Dependencies)}.";
                     return false;
                 }
 
-                // missing ID
                 if (string.IsNullOrWhiteSpace(dependency.UniqueID))
                 {
                     error = $"manifest has a {nameof(IManifest.Dependencies)} entry with no {nameof(IManifestDependency.UniqueID)} field.";
                     return false;
                 }
 
-                // invalid ID
                 if (!PathUtilities.IsSlug(dependency.UniqueID))
                 {
                     error = $"manifest has a {nameof(IManifest.Dependencies)} entry with an invalid {nameof(IManifestDependency.UniqueID)} field (IDs must only contain letters, numbers, underscores, periods, or hyphens).";

--- a/src/SMAPI.Toolkit/Serialization/Models/Manifest.cs
+++ b/src/SMAPI.Toolkit/Serialization/Models/Manifest.cs
@@ -134,15 +134,11 @@ namespace StardewModdingAPI.Toolkit.Serialization.Models
                 return false;
             }
 
-            // validate content pack
-            else if (isContentPack)
+            // validate content pack ID
+            else if (isContentPack && string.IsNullOrWhiteSpace(this.ContentPackFor!.UniqueID))
             {
-                // invalid content pack ID
-                if (string.IsNullOrWhiteSpace(this.ContentPackFor!.UniqueID))
-                {
-                    error = $"manifest declares {nameof(IManifest.ContentPackFor)} without its required {nameof(IManifestContentPackFor.UniqueID)} field.";
-                    return false;
-                }
+                error = $"manifest declares {nameof(IManifest.ContentPackFor)} without its required {nameof(IManifestContentPackFor.UniqueID)} field.";
+                return false;
             }
 
             // validate required fields

--- a/src/SMAPI.Toolkit/Serialization/Models/Manifest.cs
+++ b/src/SMAPI.Toolkit/Serialization/Models/Manifest.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
 using System.Text;
 using Newtonsoft.Json;
 using StardewModdingAPI.Toolkit.Serialization.Converters;
+using StardewModdingAPI.Toolkit.Utilities;
 
 namespace StardewModdingAPI.Toolkit.Serialization.Models
 {
@@ -101,6 +104,99 @@ namespace StardewModdingAPI.Toolkit.Serialization.Models
             this.ContentPackFor = contentPackFor;
             this.Dependencies = dependencies ?? Array.Empty<IManifestDependency>();
             this.UpdateKeys = updateKeys ?? Array.Empty<string>();
+        }
+
+        /// <summary>Try to validate a manifest's fields. Fails if any invalid field is found.</summary>
+        /// <param name="error">The error message to display to the user.</param>
+        /// <returns>Returns whether the manifest was validated successfully.</returns>
+        public bool TryValidate(out string error)
+        {
+            // validate DLL / content pack fields
+            bool hasDll = !string.IsNullOrWhiteSpace(this.EntryDll);
+            bool isContentPack = this.ContentPackFor != null;
+
+            // validate field presence
+            if (!hasDll && !isContentPack)
+            {
+                error = $"manifest has no {nameof(IManifest.EntryDll)} or {nameof(IManifest.ContentPackFor)} field; must specify one.";
+                return false;
+            }
+            if (hasDll && isContentPack)
+            {
+                error = $"manifest sets both {nameof(IManifest.EntryDll)} and {nameof(IManifest.ContentPackFor)}, which are mutually exclusive.";
+                return false;
+            }
+
+            // validate DLL filename format
+            if (hasDll && this.EntryDll!.Intersect(Path.GetInvalidFileNameChars()).Any())
+            {
+                error = $"manifest has invalid filename '{this.EntryDll}' for the EntryDLL field.";
+                return false;
+            }
+
+            // validate content pack
+            else if (isContentPack)
+            {
+                // invalid content pack ID
+                if (string.IsNullOrWhiteSpace(this.ContentPackFor!.UniqueID))
+                {
+                    error = $"manifest declares {nameof(IManifest.ContentPackFor)} without its required {nameof(IManifestContentPackFor.UniqueID)} field.";
+                    return false;
+                }
+            }
+
+            // validate required fields
+            {
+                List<string> missingFields = new List<string>(3);
+
+                if (string.IsNullOrWhiteSpace(this.Name))
+                    missingFields.Add(nameof(IManifest.Name));
+                if (this.Version == null || this.Version.ToString() == "0.0.0")
+                    missingFields.Add(nameof(IManifest.Version));
+                if (string.IsNullOrWhiteSpace(this.UniqueID))
+                    missingFields.Add(nameof(IManifest.UniqueID));
+
+                if (missingFields.Any())
+                {
+                    error = $"manifest is missing required fields ({string.Join(", ", missingFields)}).";
+                    return false;
+                }
+            }
+
+            // validate ID format
+            if (!PathUtilities.IsSlug(this.UniqueID))
+            {
+                error = "manifest specifies an invalid ID (IDs must only contain letters, numbers, underscores, periods, or hyphens).";
+                return false;
+            }
+
+            // validate dependencies
+            foreach (IManifestDependency? dependency in this.Dependencies)
+            {
+                // null dependency
+                if (dependency == null)
+                {
+                    error = $"manifest has a null entry under {nameof(IManifest.Dependencies)}.";
+                    return false;
+                }
+
+                // missing ID
+                if (string.IsNullOrWhiteSpace(dependency.UniqueID))
+                {
+                    error = $"manifest has a {nameof(IManifest.Dependencies)} entry with no {nameof(IManifestDependency.UniqueID)} field.";
+                    return false;
+                }
+
+                // invalid ID
+                if (!PathUtilities.IsSlug(dependency.UniqueID))
+                {
+                    error = $"manifest has a {nameof(IManifest.Dependencies)} entry with an invalid {nameof(IManifestDependency.UniqueID)} field (IDs must only contain letters, numbers, underscores, periods, or hyphens).";
+                    return false;
+                }
+            }
+
+            error = "";
+            return true;
         }
 
         /// <summary>Override the update keys loaded from the mod info.</summary>

--- a/src/SMAPI/Framework/ModLoading/ModResolver.cs
+++ b/src/SMAPI/Framework/ModLoading/ModResolver.cs
@@ -8,7 +8,6 @@ using StardewModdingAPI.Toolkit.Framework.ModData;
 using StardewModdingAPI.Toolkit.Framework.ModScanning;
 using StardewModdingAPI.Toolkit.Framework.UpdateData;
 using StardewModdingAPI.Toolkit.Serialization.Models;
-using StardewModdingAPI.Toolkit.Utilities;
 using StardewModdingAPI.Toolkit.Utilities.PathLookups;
 
 namespace StardewModdingAPI.Framework.ModLoading
@@ -126,100 +125,23 @@ namespace StardewModdingAPI.Framework.ModLoading
                     continue;
                 }
 
-                // validate DLL / content pack fields
+                // check for dll if it's supposed to have one
+                if (!string.IsNullOrEmpty(mod.Manifest.EntryDll) && validateFilesExist)
                 {
-                    bool hasDll = !string.IsNullOrWhiteSpace(mod.Manifest.EntryDll);
-                    bool isContentPack = mod.Manifest.ContentPackFor != null;
-
-                    // validate field presence
-                    if (!hasDll && !isContentPack)
+                    IFileLookup pathLookup = getFileLookup(mod.DirectoryPath);
+                    FileInfo file = pathLookup.GetFile(mod.Manifest.EntryDll!);
+                    if (!file.Exists)
                     {
-                        mod.SetStatus(ModMetadataStatus.Failed, ModFailReason.InvalidManifest, $"its manifest has no {nameof(IManifest.EntryDll)} or {nameof(IManifest.ContentPackFor)} field; must specify one.");
-                        continue;
-                    }
-                    if (hasDll && isContentPack)
-                    {
-                        mod.SetStatus(ModMetadataStatus.Failed, ModFailReason.InvalidManifest, $"its manifest sets both {nameof(IManifest.EntryDll)} and {nameof(IManifest.ContentPackFor)}, which are mutually exclusive.");
-                        continue;
-                    }
-
-                    // validate DLL
-                    if (hasDll)
-                    {
-                        // invalid filename format
-                        if (mod.Manifest.EntryDll!.Intersect(Path.GetInvalidFileNameChars()).Any())
-                        {
-                            mod.SetStatus(ModMetadataStatus.Failed, ModFailReason.InvalidManifest, $"its manifest has invalid filename '{mod.Manifest.EntryDll}' for the EntryDLL field.");
-                            continue;
-                        }
-
-                        // file doesn't exist
-                        if (validateFilesExist)
-                        {
-                            IFileLookup pathLookup = getFileLookup(mod.DirectoryPath);
-                            FileInfo file = pathLookup.GetFile(mod.Manifest.EntryDll!);
-                            if (!file.Exists)
-                            {
-                                mod.SetStatus(ModMetadataStatus.Failed, ModFailReason.InvalidManifest, $"its DLL '{mod.Manifest.EntryDll}' doesn't exist.");
-                                continue;
-                            }
-                        }
-                    }
-
-                    // validate content pack
-                    else
-                    {
-                        // invalid content pack ID
-                        if (string.IsNullOrWhiteSpace(mod.Manifest.ContentPackFor!.UniqueID))
-                        {
-                            mod.SetStatus(ModMetadataStatus.Failed, ModFailReason.InvalidManifest, $"its manifest declares {nameof(IManifest.ContentPackFor)} without its required {nameof(IManifestContentPackFor.UniqueID)} field.");
-                            continue;
-                        }
-                    }
-                }
-
-                // validate required fields
-                {
-                    List<string> missingFields = new List<string>(3);
-
-                    if (string.IsNullOrWhiteSpace(mod.Manifest.Name))
-                        missingFields.Add(nameof(IManifest.Name));
-                    if (mod.Manifest.Version == null || mod.Manifest.Version.ToString() == "0.0.0")
-                        missingFields.Add(nameof(IManifest.Version));
-                    if (string.IsNullOrWhiteSpace(mod.Manifest.UniqueID))
-                        missingFields.Add(nameof(IManifest.UniqueID));
-
-                    if (missingFields.Any())
-                    {
-                        mod.SetStatus(ModMetadataStatus.Failed, ModFailReason.InvalidManifest, $"its manifest is missing required fields ({string.Join(", ", missingFields)}).");
+                        mod.SetStatus(ModMetadataStatus.Failed, ModFailReason.InvalidManifest, $"its DLL '{mod.Manifest.EntryDll}' doesn't exist.");
                         continue;
                     }
                 }
 
-                // validate ID format
-                if (!PathUtilities.IsSlug(mod.Manifest.UniqueID))
-                    mod.SetStatus(ModMetadataStatus.Failed, ModFailReason.InvalidManifest, "its manifest specifies an invalid ID (IDs must only contain letters, numbers, underscores, periods, or hyphens).");
-
-                // validate dependencies
-                foreach (IManifestDependency? dependency in mod.Manifest.Dependencies)
+                // validate manifest
+                if (mod.Manifest is Manifest manifest && !manifest.TryValidate(out string manifestError))
                 {
-                    // null dependency
-                    if (dependency == null)
-                    {
-                        mod.SetStatus(ModMetadataStatus.Failed, ModFailReason.InvalidManifest, $"its manifest has a null entry under {nameof(IManifest.Dependencies)}.");
-                        continue;
-                    }
-
-                    // missing ID
-                    if (string.IsNullOrWhiteSpace(dependency.UniqueID))
-                    {
-                        mod.SetStatus(ModMetadataStatus.Failed, ModFailReason.InvalidManifest, $"its manifest has a {nameof(IManifest.Dependencies)} entry with no {nameof(IManifestDependency.UniqueID)} field.");
-                        continue;
-                    }
-
-                    // invalid ID
-                    if (!PathUtilities.IsSlug(dependency.UniqueID))
-                        mod.SetStatus(ModMetadataStatus.Failed, ModFailReason.InvalidManifest, $"its manifest has a {nameof(IManifest.Dependencies)} entry with an invalid {nameof(IManifestDependency.UniqueID)} field (IDs must only contain letters, numbers, underscores, periods, or hyphens).");
+                    mod.SetStatus(ModMetadataStatus.Failed, ModFailReason.InvalidManifest, $"its {manifestError}");
+                    continue;
                 }
             }
 

--- a/src/SMAPI/Framework/ModLoading/ModResolver.cs
+++ b/src/SMAPI/Framework/ModLoading/ModResolver.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using StardewModdingAPI.Toolkit;
+using StardewModdingAPI.Toolkit.Framework;
 using StardewModdingAPI.Toolkit.Framework.ModData;
 using StardewModdingAPI.Toolkit.Framework.ModScanning;
 using StardewModdingAPI.Toolkit.Framework.UpdateData;
@@ -138,7 +139,7 @@ namespace StardewModdingAPI.Framework.ModLoading
                 }
 
                 // validate manifest
-                if (mod.Manifest is Manifest manifest && !manifest.TryValidate(out string manifestError))
+                if (!ManifestValidator.TryValidate(mod.Manifest, out string manifestError))
                 {
                     mod.SetStatus(ModMetadataStatus.Failed, ModFailReason.InvalidManifest, $"its {manifestError}");
                     continue;

--- a/src/SMAPI/Framework/ModLoading/ModResolver.cs
+++ b/src/SMAPI/Framework/ModLoading/ModResolver.cs
@@ -126,7 +126,14 @@ namespace StardewModdingAPI.Framework.ModLoading
                     continue;
                 }
 
-                // check for dll if it's supposed to have one
+                // validate manifest format
+                if (!ManifestValidator.TryValidateFields(mod.Manifest, out string manifestError))
+                {
+                    mod.SetStatus(ModMetadataStatus.Failed, ModFailReason.InvalidManifest, $"its {manifestError}");
+                    continue;
+                }
+
+                // check that DLL exists if applicable
                 if (!string.IsNullOrEmpty(mod.Manifest.EntryDll) && validateFilesExist)
                 {
                     IFileLookup pathLookup = getFileLookup(mod.DirectoryPath);
@@ -136,13 +143,6 @@ namespace StardewModdingAPI.Framework.ModLoading
                         mod.SetStatus(ModMetadataStatus.Failed, ModFailReason.InvalidManifest, $"its DLL '{mod.Manifest.EntryDll}' doesn't exist.");
                         continue;
                     }
-                }
-
-                // validate manifest
-                if (!ManifestValidator.TryValidate(mod.Manifest, out string manifestError))
-                {
-                    mod.SetStatus(ModMetadataStatus.Failed, ModFailReason.InvalidManifest, $"its {manifestError}");
-                    continue;
                 }
             }
 


### PR DESCRIPTION
As per discussion in #making-mods [linked here](https://discord.com/channels/137344473976799233/156109690059751424/1032039820723241042).

This implementation is up for discussion. Abstracts out some of the manifest validation logic from `ModResolver` and puts it into the `Manifest` model. With this change, we can validate mod manifests at build time instead of at run time. In order to not pull in some unwanted logic from `ModResolver`, the new validation logic in `Manifest` is unable to validate if files exist on disk. This is left to be handled by `ModResolver`.

Changes ModBuildConfig to always validate manifests, regardless if auto-deploying or not.

This also has the small benefit of allowing mods to validate the manifests of other mods.