### PR TITLE
Add options to override mod load order

### DIFF
--- a/src/SMAPI/Framework/ModLoading/ModResolver.cs
+++ b/src/SMAPI/Framework/ModLoading/ModResolver.cs
@@ -263,8 +263,18 @@ namespace StardewModdingAPI.Framework.ModLoading
 
             // sort mods
             IModMetadata[] allMods = mods.ToArray();
-            IModMetadata[] modsToLoadEarly = allMods.Where(m => modIdsToLoadEarly.Contains(m.Manifest.UniqueID) && !modIdsToLoadLate.Contains(m.Manifest.UniqueID)).ToArray();
-            IModMetadata[] modsToLoadLate = allMods.Where(m => modIdsToLoadLate.Contains(m.Manifest.UniqueID) && !modIdsToLoadEarly.Contains(m.Manifest.UniqueID)).ToArray();
+            IModMetadata[] modsToLoadEarly = modIdsToLoadEarly
+                .Where(modId => !modIdsToLoadLate.Contains(modId))
+                .Select(modId => allMods.FirstOrDefault(m => m.Manifest.UniqueID == modId))
+                .Where(m => m != null)
+                .Select(m => m!)
+                .ToArray();
+            IModMetadata[] modsToLoadLate = modIdsToLoadLate
+                .Where(modId => !modIdsToLoadEarly.Contains(modId))
+                .Select(modId => allMods.FirstOrDefault(m => m.Manifest.UniqueID == modId))
+                .Where(m => m != null)
+                .Select(m => m!)
+                .ToArray();
             IModMetadata[] modsToLoadAsUsual = allMods.Where(m => !modsToLoadEarly.Contains(m) && !modsToLoadLate.Contains(m)).ToArray();
 
             List<IModMetadata> orderSortedMods = new();

--- a/src/SMAPI/Framework/ModLoading/ModResolver.cs
+++ b/src/SMAPI/Framework/ModLoading/ModResolver.cs
@@ -245,9 +245,9 @@ namespace StardewModdingAPI.Framework.ModLoading
         /// <summary>Sort the given mods by the order they should be loaded.</summary>
         /// <param name="mods">The mods to process.</param>
         /// <param name="modDatabase">Handles access to SMAPI's internal mod metadata list.</param>
-        /// <param name="modIdsToLoadFirst">The mod IDs SMAPI should try to load first, before any other mods not included in this list.</param>
-        /// <param name="modIdsToLoadLast">The mod IDs SMAPI should try to load last, after all other mods not included in this list.</param>
-        public IEnumerable<IModMetadata> ProcessDependencies(IEnumerable<IModMetadata> mods, IReadOnlyList<string> modIdsToLoadFirst, IReadOnlyList<string> modIdsToLoadLast, ModDatabase modDatabase)
+        /// <param name="modIdsToLoadEarly">The mod IDs SMAPI should try to load early, before any other mods not included in this list.</param>
+        /// <param name="modIdsToLoadLate">The mod IDs SMAPI should try to load late, after all other mods not included in this list.</param>
+        public IEnumerable<IModMetadata> ProcessDependencies(IEnumerable<IModMetadata> mods, IReadOnlyList<string> modIdsToLoadEarly, IReadOnlyList<string> modIdsToLoadLate, ModDatabase modDatabase)
         {
             // initialize metadata
             mods = mods.ToArray();
@@ -263,14 +263,14 @@ namespace StardewModdingAPI.Framework.ModLoading
 
             // sort mods
             IModMetadata[] allMods = mods.ToArray();
-            IModMetadata[] modsToLoadFirst = allMods.Where(m => modIdsToLoadFirst.Contains(m.Manifest.UniqueID)).ToArray();
-            IModMetadata[] modsToLoadLast = allMods.Where(m => modIdsToLoadLast.Contains(m.Manifest.UniqueID)).ToArray();
-            IModMetadata[] modsToLoadAsUsual = allMods.Where(m => !modsToLoadFirst.Contains(m) && !modsToLoadLast.Contains(m)).ToArray();
+            IModMetadata[] modsToLoadEarly = allMods.Where(m => modIdsToLoadEarly.Contains(m.Manifest.UniqueID) && !modIdsToLoadLate.Contains(m.Manifest.UniqueID)).ToArray();
+            IModMetadata[] modsToLoadLate = allMods.Where(m => modIdsToLoadLate.Contains(m.Manifest.UniqueID) && !modIdsToLoadEarly.Contains(m.Manifest.UniqueID)).ToArray();
+            IModMetadata[] modsToLoadAsUsual = allMods.Where(m => !modsToLoadEarly.Contains(m) && !modsToLoadLate.Contains(m)).ToArray();
 
             List<IModMetadata> orderSortedMods = new();
-            orderSortedMods.AddRange(modsToLoadFirst);
+            orderSortedMods.AddRange(modsToLoadEarly);
             orderSortedMods.AddRange(modsToLoadAsUsual);
-            orderSortedMods.AddRange(modsToLoadLast);
+            orderSortedMods.AddRange(modsToLoadLate);
 
             foreach (IModMetadata mod in orderSortedMods)
                 this.ProcessDependencies(orderSortedMods, modDatabase, mod, states, sortedMods, new List<IModMetadata>());

--- a/src/SMAPI/Framework/Models/SConfig.cs
+++ b/src/SMAPI/Framework/Models/SConfig.cs
@@ -146,6 +146,12 @@ namespace StardewModdingAPI.Framework.Models
                     custom[name] = value;
             }
 
+            if (this.ModsToLoadEarly.Any())
+                custom[nameof(this.ModsToLoadEarly)] = $"[{string.Join(", ", this.ModsToLoadEarly)}]";
+
+            if (this.ModsToLoadLate.Any())
+                custom[nameof(this.ModsToLoadLate)] = $"[{string.Join(", ", this.ModsToLoadLate)}]";
+
             if (!this.SuppressUpdateChecks.SetEquals(SConfig.DefaultSuppressUpdateChecks))
                 custom[nameof(this.SuppressUpdateChecks)] = $"[{string.Join(", ", this.SuppressUpdateChecks)}]";
 

--- a/src/SMAPI/Framework/Models/SConfig.cs
+++ b/src/SMAPI/Framework/Models/SConfig.cs
@@ -82,11 +82,11 @@ namespace StardewModdingAPI.Framework.Models
         /// <summary>The mod IDs SMAPI should ignore when performing update checks or validating update keys.</summary>
         public HashSet<string> SuppressUpdateChecks { get; set; }
 
-        /// <summary>The mod IDs SMAPI should try to load first, before any other mods not included in this list.</summary>
-        public List<string> ModsToLoadFirst { get; set; }
+        /// <summary>The mod IDs SMAPI should try to load early, before any other mods not included in this list.</summary>
+        public List<string> ModsToLoadEarly { get; set; }
 
-        /// <summary>The mod IDs SMAPI should try to load last, after all other mods not included in this list.</summary>
-        public List<string> ModsToLoadLast { get; set; }
+        /// <summary>The mod IDs SMAPI should try to load late, after all other mods not included in this list.</summary>
+        public List<string> ModsToLoadLate { get; set; }
 
 
         /********
@@ -106,9 +106,9 @@ namespace StardewModdingAPI.Framework.Models
         /// <param name="consoleColors">The colors to use for text written to the SMAPI console.</param>
         /// <param name="suppressHarmonyDebugMode">Whether to prevent mods from enabling Harmony's debug mode, which impacts performance and creates a file on your desktop. Debug mode should never be enabled by a released mod.</param>
         /// <param name="suppressUpdateChecks">The mod IDs SMAPI should ignore when performing update checks or validating update keys.</param>
-        /// <param name="modsToLoadFirst">The mod IDs SMAPI should try to load first, before any other mods not included in this list.</param>
-        /// <param name="modsToLoadLast">The mod IDs SMAPI should try to load last, after all other mods not included in this list.</param>
-        public SConfig(bool developerMode, bool? checkForUpdates, bool? paranoidWarnings, bool? useBetaChannel, string gitHubProjectName, string webApiBaseUrl, string[]? verboseLogging, bool? rewriteMods, bool? useCaseInsensitivePaths, bool? logNetworkTraffic, ColorSchemeConfig consoleColors, bool? suppressHarmonyDebugMode, string[]? suppressUpdateChecks, string[]? modsToLoadFirst, string[]? modsToLoadLast)
+        /// <param name="modsToLoadEarly">The mod IDs SMAPI should try to load early, before any other mods not included in this list.</param>
+        /// <param name="modsToLoadLate">The mod IDs SMAPI should try to load late, after all other mods not included in this list.</param>
+        public SConfig(bool developerMode, bool? checkForUpdates, bool? paranoidWarnings, bool? useBetaChannel, string gitHubProjectName, string webApiBaseUrl, string[]? verboseLogging, bool? rewriteMods, bool? useCaseInsensitivePaths, bool? logNetworkTraffic, ColorSchemeConfig consoleColors, bool? suppressHarmonyDebugMode, string[]? suppressUpdateChecks, string[]? modsToLoadEarly, string[]? modsToLoadLate)
         {
             this.DeveloperMode = developerMode;
             this.CheckForUpdates = checkForUpdates ?? (bool)SConfig.DefaultValues[nameof(this.CheckForUpdates)];
@@ -123,8 +123,8 @@ namespace StardewModdingAPI.Framework.Models
             this.ConsoleColors = consoleColors;
             this.SuppressHarmonyDebugMode = suppressHarmonyDebugMode ?? (bool)SConfig.DefaultValues[nameof(this.SuppressHarmonyDebugMode)];
             this.SuppressUpdateChecks = new HashSet<string>(suppressUpdateChecks ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
-            this.ModsToLoadFirst = new List<string>(modsToLoadFirst ?? Array.Empty<string>());
-            this.ModsToLoadLast = new List<string>(modsToLoadLast ?? Array.Empty<string>());
+            this.ModsToLoadEarly = new List<string>(modsToLoadEarly ?? Array.Empty<string>());
+            this.ModsToLoadLate = new List<string>(modsToLoadLate ?? Array.Empty<string>());
         }
 
         /// <summary>Override the value of <see cref="DeveloperMode"/>.</summary>

--- a/src/SMAPI/Framework/Models/SConfig.cs
+++ b/src/SMAPI/Framework/Models/SConfig.cs
@@ -82,11 +82,11 @@ namespace StardewModdingAPI.Framework.Models
         /// <summary>The mod IDs SMAPI should ignore when performing update checks or validating update keys.</summary>
         public HashSet<string> SuppressUpdateChecks { get; set; }
 
-        /// <summary>The mod IDs SMAPI should try to load early, before any other mods not included in this list.</summary>
-        public List<string> ModsToLoadEarly { get; set; }
+        /// <summary>The mod IDs SMAPI should load before any other mods (except those needed to load them).</summary>
+        public HashSet<string> ModsToLoadEarly { get; set; }
 
-        /// <summary>The mod IDs SMAPI should try to load late, after all other mods not included in this list.</summary>
-        public List<string> ModsToLoadLate { get; set; }
+        /// <summary>The mod IDs SMAPI should load after any other mods.</summary>
+        public HashSet<string> ModsToLoadLate { get; set; }
 
 
         /********
@@ -106,8 +106,8 @@ namespace StardewModdingAPI.Framework.Models
         /// <param name="consoleColors">The colors to use for text written to the SMAPI console.</param>
         /// <param name="suppressHarmonyDebugMode">Whether to prevent mods from enabling Harmony's debug mode, which impacts performance and creates a file on your desktop. Debug mode should never be enabled by a released mod.</param>
         /// <param name="suppressUpdateChecks">The mod IDs SMAPI should ignore when performing update checks or validating update keys.</param>
-        /// <param name="modsToLoadEarly">The mod IDs SMAPI should try to load early, before any other mods not included in this list.</param>
-        /// <param name="modsToLoadLate">The mod IDs SMAPI should try to load late, after all other mods not included in this list.</param>
+        /// <param name="modsToLoadEarly">The mod IDs SMAPI should load before any other mods (except those needed to load them).</param>
+        /// <param name="modsToLoadLate">The mod IDs SMAPI should load after any other mods.</param>
         public SConfig(bool developerMode, bool? checkForUpdates, bool? paranoidWarnings, bool? useBetaChannel, string gitHubProjectName, string webApiBaseUrl, string[]? verboseLogging, bool? rewriteMods, bool? useCaseInsensitivePaths, bool? logNetworkTraffic, ColorSchemeConfig consoleColors, bool? suppressHarmonyDebugMode, string[]? suppressUpdateChecks, string[]? modsToLoadEarly, string[]? modsToLoadLate)
         {
             this.DeveloperMode = developerMode;
@@ -123,8 +123,8 @@ namespace StardewModdingAPI.Framework.Models
             this.ConsoleColors = consoleColors;
             this.SuppressHarmonyDebugMode = suppressHarmonyDebugMode ?? (bool)SConfig.DefaultValues[nameof(this.SuppressHarmonyDebugMode)];
             this.SuppressUpdateChecks = new HashSet<string>(suppressUpdateChecks ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
-            this.ModsToLoadEarly = new List<string>(modsToLoadEarly ?? Array.Empty<string>());
-            this.ModsToLoadLate = new List<string>(modsToLoadLate ?? Array.Empty<string>());
+            this.ModsToLoadEarly = new HashSet<string>(modsToLoadEarly ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+            this.ModsToLoadLate = new HashSet<string>(modsToLoadLate ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>Override the value of <see cref="DeveloperMode"/>.</summary>

--- a/src/SMAPI/Framework/Models/SConfig.cs
+++ b/src/SMAPI/Framework/Models/SConfig.cs
@@ -82,6 +82,12 @@ namespace StardewModdingAPI.Framework.Models
         /// <summary>The mod IDs SMAPI should ignore when performing update checks or validating update keys.</summary>
         public HashSet<string> SuppressUpdateChecks { get; set; }
 
+        /// <summary>The mod IDs SMAPI should try to load first, before any other mods not included in this list.</summary>
+        public List<string> ModsToLoadFirst { get; set; }
+
+        /// <summary>The mod IDs SMAPI should try to load last, after all other mods not included in this list.</summary>
+        public List<string> ModsToLoadLast { get; set; }
+
 
         /********
         ** Public methods
@@ -100,7 +106,9 @@ namespace StardewModdingAPI.Framework.Models
         /// <param name="consoleColors">The colors to use for text written to the SMAPI console.</param>
         /// <param name="suppressHarmonyDebugMode">Whether to prevent mods from enabling Harmony's debug mode, which impacts performance and creates a file on your desktop. Debug mode should never be enabled by a released mod.</param>
         /// <param name="suppressUpdateChecks">The mod IDs SMAPI should ignore when performing update checks or validating update keys.</param>
-        public SConfig(bool developerMode, bool? checkForUpdates, bool? paranoidWarnings, bool? useBetaChannel, string gitHubProjectName, string webApiBaseUrl, string[]? verboseLogging, bool? rewriteMods, bool? useCaseInsensitivePaths, bool? logNetworkTraffic, ColorSchemeConfig consoleColors, bool? suppressHarmonyDebugMode, string[]? suppressUpdateChecks)
+        /// <param name="modsToLoadFirst">The mod IDs SMAPI should try to load first, before any other mods not included in this list.</param>
+        /// <param name="modsToLoadLast">The mod IDs SMAPI should try to load last, after all other mods not included in this list.</param>
+        public SConfig(bool developerMode, bool? checkForUpdates, bool? paranoidWarnings, bool? useBetaChannel, string gitHubProjectName, string webApiBaseUrl, string[]? verboseLogging, bool? rewriteMods, bool? useCaseInsensitivePaths, bool? logNetworkTraffic, ColorSchemeConfig consoleColors, bool? suppressHarmonyDebugMode, string[]? suppressUpdateChecks, string[]? modsToLoadFirst, string[]? modsToLoadLast)
         {
             this.DeveloperMode = developerMode;
             this.CheckForUpdates = checkForUpdates ?? (bool)SConfig.DefaultValues[nameof(this.CheckForUpdates)];
@@ -115,6 +123,8 @@ namespace StardewModdingAPI.Framework.Models
             this.ConsoleColors = consoleColors;
             this.SuppressHarmonyDebugMode = suppressHarmonyDebugMode ?? (bool)SConfig.DefaultValues[nameof(this.SuppressHarmonyDebugMode)];
             this.SuppressUpdateChecks = new HashSet<string>(suppressUpdateChecks ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+            this.ModsToLoadFirst = new List<string>(modsToLoadFirst ?? Array.Empty<string>());
+            this.ModsToLoadLast = new List<string>(modsToLoadLast ?? Array.Empty<string>());
         }
 
         /// <summary>Override the value of <see cref="DeveloperMode"/>.</summary>

--- a/src/SMAPI/Framework/SCore.cs
+++ b/src/SMAPI/Framework/SCore.cs
@@ -426,10 +426,10 @@ namespace StardewModdingAPI.Framework
                 // warn about mods that should load early or late which are not found at all, or both
                 foreach (string modId in this.Settings.ModsToLoadEarly)
                     if (!mods.Any(m => m.Manifest.UniqueID == modId))
-                        this.Monitor.Log($"  SMAPI configuration specifies a mod {modId} that should load early, but it could not be found.", LogLevel.Warn);
+                        this.Monitor.Log($"  SMAPI configuration specifies a mod {modId} that should load early, but it could not be found or was skipped.", LogLevel.Warn);
                 foreach (string modId in this.Settings.ModsToLoadLate)
                     if (!mods.Any(m => m.Manifest.UniqueID == modId))
-                        this.Monitor.Log($"  SMAPI configuration specifies a mod {modId} that should load late, but it could not be found.", LogLevel.Warn);
+                        this.Monitor.Log($"  SMAPI configuration specifies a mod {modId} that should load late, but it could not be found or was skipped.", LogLevel.Warn);
                 foreach (string modId in this.Settings.ModsToLoadEarly)
                     if (this.Settings.ModsToLoadLate.Contains(modId))
                         this.Monitor.Log($"  SMAPI configuration specifies a mod {modId} that should load both early and late - this will be ignored.", LogLevel.Warn);

--- a/src/SMAPI/Framework/SCore.cs
+++ b/src/SMAPI/Framework/SCore.cs
@@ -423,17 +423,20 @@ namespace StardewModdingAPI.Framework
                     this.Monitor.Log($"  Skipped {mod.GetRelativePathWithRoot()} (folder name starts with a dot).");
                 mods = mods.Where(p => !p.IsIgnored).ToArray();
 
-                // warn about mods that should load first or last which are not found at all
-                foreach (string modId in this.Settings.ModsToLoadFirst)
+                // warn about mods that should load early or late which are not found at all, or both
+                foreach (string modId in this.Settings.ModsToLoadEarly)
                     if (!mods.Any(m => m.Manifest.UniqueID == modId))
-                        this.Monitor.Log($"  SMAPI configuration specifies a mod {modId} that should load first, but it could not be found.", LogLevel.Warn);
-                foreach (string modId in this.Settings.ModsToLoadLast)
+                        this.Monitor.Log($"  SMAPI configuration specifies a mod {modId} that should load early, but it could not be found.", LogLevel.Warn);
+                foreach (string modId in this.Settings.ModsToLoadLate)
                     if (!mods.Any(m => m.Manifest.UniqueID == modId))
-                        this.Monitor.Log($"  SMAPI configuration specifies a mod {modId} that should load last, but it could not be found.", LogLevel.Warn);
+                        this.Monitor.Log($"  SMAPI configuration specifies a mod {modId} that should load late, but it could not be found.", LogLevel.Warn);
+                foreach (string modId in this.Settings.ModsToLoadEarly)
+                    if (this.Settings.ModsToLoadLate.Contains(modId))
+                        this.Monitor.Log($"  SMAPI configuration specifies a mod {modId} that should load both early and late - this will be ignored.", LogLevel.Warn);
 
                 // load mods
                 resolver.ValidateManifests(mods, Constants.ApiVersion, toolkit.GetUpdateUrl, getFileLookup: this.GetFileLookup);
-                mods = resolver.ProcessDependencies(mods, this.Settings.ModsToLoadFirst, this.Settings.ModsToLoadLast, modDatabase).ToArray();
+                mods = resolver.ProcessDependencies(mods, this.Settings.ModsToLoadEarly, this.Settings.ModsToLoadLate, modDatabase).ToArray();
                 this.LoadMods(mods, this.Toolkit.JsonHelper, this.ContentCore, modDatabase);
 
                 // check for software likely to cause issues

--- a/src/SMAPI/Framework/SCore.cs
+++ b/src/SMAPI/Framework/SCore.cs
@@ -423,7 +423,11 @@ namespace StardewModdingAPI.Framework
                     this.Monitor.Log($"  Skipped {mod.GetRelativePathWithRoot()} (folder name starts with a dot).");
                 mods = mods.Where(p => !p.IsIgnored).ToArray();
 
-                // warn about mods that should load early or late which are not found at all, or both
+                // validate manifests
+                resolver.ValidateManifests(mods, Constants.ApiVersion, toolkit.GetUpdateUrl, getFileLookup: this.GetFileLookup);
+
+                // apply load order customizations
+                if (this.Settings.ModsToLoadEarly.Any() || this.Settings.ModsToLoadLate.Any())
                 {
                     HashSet<string> installedIds = new HashSet<string>(mods.Select(p => p.Manifest.UniqueID), StringComparer.OrdinalIgnoreCase);
 
@@ -437,11 +441,11 @@ namespace StardewModdingAPI.Framework
                         this.Monitor.Log($"  The 'smapi-internal/config.json' file lists mod IDs in {nameof(this.Settings.ModsToLoadLate)} which aren't installed: '{string.Join("', '", missingLateMods)}'.", LogLevel.Warn);
                     if (duplicateMods.Any())
                         this.Monitor.Log($"  The 'smapi-internal/config.json' file lists mod IDs which are in both {nameof(this.Settings.ModsToLoadEarly)} and {nameof(this.Settings.ModsToLoadLate)}: '{string.Join("', '", duplicateMods)}'. These will be loaded early.", LogLevel.Warn);
+
+                    mods = resolver.ApplyLoadOrderOverrides(mods, this.Settings.ModsToLoadEarly, this.Settings.ModsToLoadLate);
                 }
 
                 // load mods
-                resolver.ValidateManifests(mods, Constants.ApiVersion, toolkit.GetUpdateUrl, getFileLookup: this.GetFileLookup);
-                mods = resolver.ApplyLoadOrderOverrides(mods, this.Settings.ModsToLoadEarly, this.Settings.ModsToLoadLate);
                 mods = resolver.ProcessDependencies(mods, modDatabase).ToArray();
                 this.LoadMods(mods, this.Toolkit.JsonHelper, this.ContentCore, modDatabase);
 

--- a/src/SMAPI/SMAPI.config.json
+++ b/src/SMAPI/SMAPI.config.json
@@ -141,5 +141,15 @@ copy all the settings, or you may cause bugs due to overridden changes in future
         "SMAPI.ConsoleCommands",
         "SMAPI.ErrorHandler",
         "SMAPI.SaveBackup"
-    ]
+    ],
+
+    /**
+     * The mod IDs SMAPI should try to load first, before any other mods not included in this list.
+     */
+    "ModsToLoadFirst": [],
+
+    /**
+     * The mod IDs SMAPI should try to load last, after all other mods not included in this list.
+     */
+    "ModsToLoadLast": []
 }

--- a/src/SMAPI/SMAPI.config.json
+++ b/src/SMAPI/SMAPI.config.json
@@ -144,12 +144,12 @@ copy all the settings, or you may cause bugs due to overridden changes in future
     ],
 
     /**
-     * The mod IDs SMAPI should try to load first, before any other mods not included in this list.
+     * The mod IDs SMAPI should try to load early, before any other mods not included in this list.
      */
-    "ModsToLoadFirst": [],
+    "ModsToLoadEarly": [],
 
     /**
-     * The mod IDs SMAPI should try to load last, after all other mods not included in this list.
+     * The mod IDs SMAPI should try to load late, after all other mods not included in this list.
      */
-    "ModsToLoadLast": []
+    "ModsToLoadLate": []
 }

--- a/src/SMAPI/SMAPI.config.json
+++ b/src/SMAPI/SMAPI.config.json
@@ -144,12 +144,14 @@ copy all the settings, or you may cause bugs due to overridden changes in future
     ],
 
     /**
-     * The mod IDs SMAPI should try to load early, before any other mods not included in this list.
+     * The mod IDs SMAPI should load before any other mods (except those needed to load them)
+     * or after any other mods.
+     *
+     * This lets you manually fix the load order if needed, but this is a last resort — SMAPI
+     * automatically adjusts the load order based on mods' dependencies, so needing to manually
+     * edit the order is usually a problem with one or both mods' metadata that can be reported to
+     * the mod author.
      */
     "ModsToLoadEarly": [],
-
-    /**
-     * The mod IDs SMAPI should try to load late, after all other mods not included in this list.
-     */
     "ModsToLoadLate": []
 }


### PR DESCRIPTION
This PR adds two new `config.json` keys users can set: `ModsToLoadEarly` and `ModsToLoadLate`.

In theory, mods should co-exist with each other just fine by just declaring their dependencies properly, but this is not always the case:
* A mod may want to load before other mods to hook into code commonly called in other mods or do some exotic setup it needs before other mods start doing so. One potential example would be a mod which moves other mods' `config.json` (and possibly other) files to a different path (to keep the mods' directories in a "pristine" state, making it easier to update those manually by just removing old folders and putting new ones in place - this would keep mod configs in a safe place). Another example could be SpriteMaster, which may want to do its rendering magic before any other mod uses the graphics context.
* A user may want to load a specific mod after other mods, because they have another mod modifying the same asset, and they want one or the other to "win". This case was usually handled by users modifying the mods' `manifest.json` to include the other conflicting mod as an optional ("false") dependency, which does work, but is not really a great solution, and updating such a mod would reset the modified file to its original state.

This PR handles all of those cases. A mod cannot directly tell SMAPI they want to be loaded first or last - this would definitely at some point lead to in-fighting between multiple mods all wanting to load before other mods (effectively loading in the same order they would normally). Instead, it's the user that has to do specify the order, by modifying their SMAPI `config.json` file. This configuration should be used sparingly, if a mod REALLY needs to go first/last.

In theory, a C# mod could modify the SMAPI `config.json` file at runtime to modify the load order during the next run, but that's not something I can really stop. Honestly, I'd consider that malicious behavior, and if a mod does that, it could be blacklisted via smapi.io (this is an actual feature, right? at least I believe I heard about it).