### PR TITLE
AssetName.StartsWith - fix yet another case with the trailing slash

### DIFF
--- a/src/SMAPI.Tests/Core/AssetNameTests.cs
+++ b/src/SMAPI.Tests/Core/AssetNameTests.cs
@@ -265,6 +265,26 @@ namespace SMAPI.Tests.Core
             return name.StartsWith(otherAssetName, allowPartialWord: true, allowSubfolder: allowSubfolder);
         }
 
+        // the enumerator strips the trailing path seperator
+        // so each of these cases has to be handled on each branch.
+        [TestCase("Mods/SomeMod", "Mods/", false, ExpectedResult = true)]
+        [TestCase("Mods/SomeMod", "Mods", false, ExpectedResult = false)]
+        [TestCase("Mods/Jasper/Data", "Mods/Jas/", false, ExpectedResult = false)]
+        [TestCase("Mods/Jasper/Data", "Mods/Jas", false, ExpectedResult = false)]
+        [TestCase("Mods/Jas", "Mods/Jas/", false, ExpectedResult = false)]
+        [TestCase("Mods/Jas", "Mods/Jas", false, ExpectedResult = true)]
+        public bool StartsWith_PrefixHasSeperator(string mainAssetName, string otherAssetName, bool allowSubfolder)
+        {
+            // arrange
+            mainAssetName = PathUtilities.NormalizeAssetName(mainAssetName);
+
+            // act
+            AssetName name = AssetName.Parse(mainAssetName, _ => null);
+
+            // assert value
+            return name.StartsWith(otherAssetName, allowPartialWord: true, allowSubfolder: allowSubfolder);
+        }
+
 
         /****
         ** GetHashCode

--- a/src/SMAPI.Tests/Core/AssetNameTests.cs
+++ b/src/SMAPI.Tests/Core/AssetNameTests.cs
@@ -265,15 +265,14 @@ namespace SMAPI.Tests.Core
             return name.StartsWith(otherAssetName, allowPartialWord: true, allowSubfolder: allowSubfolder);
         }
 
-        // the enumerator strips the trailing path seperator
-        // so each of these cases has to be handled on each branch.
+        // The enumerator strips the trailing path separator, so each of these cases has to be handled on each branch.
         [TestCase("Mods/SomeMod", "Mods/", false, ExpectedResult = true)]
         [TestCase("Mods/SomeMod", "Mods", false, ExpectedResult = false)]
         [TestCase("Mods/Jasper/Data", "Mods/Jas/", false, ExpectedResult = false)]
         [TestCase("Mods/Jasper/Data", "Mods/Jas", false, ExpectedResult = false)]
         [TestCase("Mods/Jas", "Mods/Jas/", false, ExpectedResult = false)]
         [TestCase("Mods/Jas", "Mods/Jas", false, ExpectedResult = true)]
-        public bool StartsWith_PrefixHasSeperator(string mainAssetName, string otherAssetName, bool allowSubfolder)
+        public bool StartsWith_PrefixHasSeparator(string mainAssetName, string otherAssetName, bool allowSubfolder)
         {
             // arrange
             mainAssetName = PathUtilities.NormalizeAssetName(mainAssetName);

--- a/src/SMAPI/Framework/Content/AssetName.cs
+++ b/src/SMAPI/Framework/Content/AssetName.cs
@@ -163,7 +163,7 @@ namespace StardewModdingAPI.Framework.Content
                         return false;
 
                     // match if subfolder paths are fine (e.g. prefix 'Data/Events' with target 'Data/Events/Beach')
-                    return allowSubfolder;
+                    return allowSubfolder || (pathSeparators.Contains(trimmedPrefix[^1]) && curParts.Remainder.Length == 0);
                 }
 
                 // previous segments matched exactly and both reached the end

--- a/src/SMAPI/Framework/Content/AssetName.cs
+++ b/src/SMAPI/Framework/Content/AssetName.cs
@@ -162,10 +162,14 @@ namespace StardewModdingAPI.Framework.Content
                     if (prefixHasMore)
                         return false;
 
-                    // match if subfolder paths are fine (e.g. prefix 'Data/Events' with target 'Data/Events/Beach')
-                    // special case if the original prefix ended with a '/' - subfolder checking pushes forward one, to check the Remainder instead of Current
-                    // which is necessarily nonzero in this block.
-                    return allowSubfolder || (pathSeparators.Contains(trimmedPrefix[^1]) && curParts.Remainder.Length == 0);
+                    // match: every segment in the prefix matched and subfolders are allowed (e.g. prefix 'Data/Events' with target 'Data/Events/Beach')
+                    if (allowSubfolder)
+                        return true;
+
+                    // Special case: the prefix ends with a path separator, but subfolders aren't allowed. This case
+                    // matches if there's no further path separator in the asset name *after* the current separator.
+                    // For example, the prefix 'A/B/' matches 'A/B/C' but not 'A/B/C/D'.
+                    return pathSeparators.Contains(trimmedPrefix[^1]) && curParts.Remainder.Length == 0;
                 }
 
                 // previous segments matched exactly and both reached the end

--- a/src/SMAPI/Framework/Content/AssetName.cs
+++ b/src/SMAPI/Framework/Content/AssetName.cs
@@ -163,6 +163,8 @@ namespace StardewModdingAPI.Framework.Content
                         return false;
 
                     // match if subfolder paths are fine (e.g. prefix 'Data/Events' with target 'Data/Events/Beach')
+                    // special case if the original prefix ended with a '/' - subfolder checking pushes forward one, to check the Remainder instead of Current
+                    // which is necessarily nonzero in this block.
                     return allowSubfolder || (pathSeparators.Contains(trimmedPrefix[^1]) && curParts.Remainder.Length == 0);
                 }
 


### PR DESCRIPTION
Hi Pathos,

I think this was the test case I was failing to think of last night - the distinction between a prefix of `Maps/` and `Maps`. What I got confused by was the fact that currParts.Current would never be zero if it was in that block, so half the ternary was pointless, but it still needs to push forward one (aka "check Remainder, not Current" if the original prefix ended with a path separator.)

I've added tests on this