### PR TITLE
Fix overlay transparency crop not always starting at end of pixel area

### DIFF
--- a/src/SMAPI/Framework/Content/AssetDataForImage.cs
+++ b/src/SMAPI/Framework/Content/AssetDataForImage.cs
@@ -163,7 +163,8 @@ namespace StardewModdingAPI.Framework.Content
             int startIndex = -1;
             int endIndex = -1;
             {
-                for (int i = startRow * sourceArea.Width; i < pixelCount; i++)
+                int endPixel = pixelCount + startRow * sourceArea.Width;
+                for (int i = startRow * sourceArea.Width; i < endPixel; i++)
                 {
                     if (sourceData[i].A >= AssetDataForImage.MinOpacity)
                     {
@@ -174,7 +175,7 @@ namespace StardewModdingAPI.Framework.Content
                 if (startIndex == -1)
                     return; // blank texture
 
-                for (int i = startRow * sourceArea.Width + pixelCount - 1; i >= startIndex; i--)
+                for (int i = endPixel - 1; i >= startIndex; i--)
                 {
                     if (sourceData[i].A >= AssetDataForImage.MinOpacity)
                     {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/94934860/201716355-ae757531-8486-4d07-a2c4-0ba12348fd70.png)

Hi Pathos!

Saw [this](https://forums.nexusmods.com/index.php?/topic/6424026-content-patcher/page-257#entry117684738) - turns out I wasn't accounting for startRow while calculating the endpixel while trying to skip past transparent bits of spritesheet.

My apologies!

atra