### PR TITLE
Replace slingshot ID check with type field check

### DIFF
--- a/src/SMAPI.Mods.ConsoleCommands/Framework/ItemRepository.cs
+++ b/src/SMAPI.Mods.ConsoleCommands/Framework/ItemRepository.cs
@@ -104,13 +104,18 @@ namespace StardewModdingAPI.Mods.ConsoleCommands.Framework
                 // weapons
                 if (ShouldGet(ItemType.Weapon))
                 {
-					var weaponsData = this.TryLoad<int, string>("Data\\weapons");
-                    foreach (int id in weaponsData.Keys)
+                    Dictionary<int, string> weaponsData = this.TryLoad<int, string>("Data\\weapons");
+                    foreach (KeyValuePair<int, string> pair in weaponsData)
                     {
-                        yield return this.TryCreate(ItemType.Weapon, id, p => weaponsData[p.ID].Split('/')[8] == "4"
-                            ? new Slingshot(p.ID)
-                            : new MeleeWeapon(p.ID)
-                        );
+                        string rawFields = pair.Value;
+                        yield return this.TryCreate(ItemType.Weapon, pair.Key, p =>
+                        {
+                            string[] fields = rawFields.Split('/');
+                            bool isSlingshot = fields.Length > 8 && fields[8] == "4";
+                            return isSlingshot
+                                ? new Slingshot(p.ID)
+                                : new MeleeWeapon(p.ID);
+                        });
                     }
                 }
 

--- a/src/SMAPI.Mods.ConsoleCommands/Framework/ItemRepository.cs
+++ b/src/SMAPI.Mods.ConsoleCommands/Framework/ItemRepository.cs
@@ -104,9 +104,10 @@ namespace StardewModdingAPI.Mods.ConsoleCommands.Framework
                 // weapons
                 if (ShouldGet(ItemType.Weapon))
                 {
-                    foreach (int id in this.TryLoad<int, string>("Data\\weapons").Keys)
+					var weaponsData = this.TryLoad<int, string>("Data\\weapons");
+                    foreach (int id in weaponsData.Keys)
                     {
-                        yield return this.TryCreate(ItemType.Weapon, id, p => p.ID is >= 32 and <= 34
+                        yield return this.TryCreate(ItemType.Weapon, id, p => weaponsData[p.ID].Split('/')[8] == "4"
                             ? new Slingshot(p.ID)
                             : new MeleeWeapon(p.ID)
                         );


### PR DESCRIPTION
The current implementation checks for slingshots by the ID's of vanilla slingshots, which fails to consider that mods may add custom slingshots. Meanwhile the slingshot weapon type is sitting unused inside "Data/weapons".