### PR TITLE
Mod-group specific config.json overriding

### DIFF
--- a/src/SMAPI/Constants.cs
+++ b/src/SMAPI/Constants.cs
@@ -142,6 +142,9 @@ namespace StardewModdingAPI
         /// <summary>The file path for the overrides file for <see cref="ApiConfigPath"/>, which is applied over it.</summary>
         internal static string ApiUserConfigPath => Path.Combine(Constants.InternalFilesPath, "config.user.json");
 
+        /// <summary>The mod-group-specific file path for the overrides file for <see cref="ApiConfigPath"/>, which is applied over it.</summary>
+        internal static string ApiModGroupConfigPath => Path.Combine(ModsPath, "config.json");
+
         /// <summary>The file path for the SMAPI metadata file.</summary>
         internal static string ApiMetadataPath => Path.Combine(Constants.InternalFilesPath, "metadata.json");
 

--- a/src/SMAPI/Framework/SCore.cs
+++ b/src/SMAPI/Framework/SCore.cs
@@ -197,6 +197,8 @@ namespace StardewModdingAPI.Framework
             this.Settings = JsonConvert.DeserializeObject<SConfig>(File.ReadAllText(Constants.ApiConfigPath)) ?? throw new InvalidOperationException("The 'smapi-internal/config.json' file is missing or invalid. You can reinstall SMAPI to fix this.");
             if (File.Exists(Constants.ApiUserConfigPath))
                 JsonConvert.PopulateObject(File.ReadAllText(Constants.ApiUserConfigPath), this.Settings);
+            if (File.Exists(Constants.ApiModGroupConfigPath))
+                JsonConvert.PopulateObject(File.ReadAllText(Constants.ApiModGroupConfigPath), this.Settings);
             if (developerMode.HasValue)
                 this.Settings.OverrideDeveloperMode(developerMode.Value);
 


### PR DESCRIPTION
Hey @Pathoschild, this PR adds mod-group specific `config.json` overriding. The `smapi-internal/config.json` file is loaded first, then `smapi-internal/config.user.json` (overriding any settings), then a `config.json` file located directly in the current mod group's directory (overriding any settings again).

This will be mainly useful for developers, so they can have a development-specific mod group, with `DeveloperMode` enabled (and maybe some other stuff if needed), but mod users can also get some benefits out of this, mainly complementing the new `ModsToLoadEarly` and `ModsToLoadLate`, but also `SuppressUpdateChecks` config values.