### PR TITLE
Use more portable shebangs

### DIFF
--- a/build/unix/prepare-install-package.sh
+++ b/build/unix/prepare-install-package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 #

--- a/build/unix/set-smapi-version.sh
+++ b/build/unix/set-smapi-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 #

--- a/build/windows/finalize-install-package.sh
+++ b/build/windows/finalize-install-package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ##########
 ## Read config

--- a/src/SMAPI.Installer/assets/install on Linux.sh
+++ b/src/SMAPI.Installer/assets/install on Linux.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "`dirname "$0"`"
 internal/linux/SMAPI.Installer

--- a/src/SMAPI.Installer/assets/install on macOS.command
+++ b/src/SMAPI.Installer/assets/install on macOS.command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "`dirname "$0"`"
 


### PR DESCRIPTION
While attempting to install SMAPI I encountered this error:

```shell
$ ./install\ on\ Linux.sh
zsh: ./install on Linux.sh: bad interpreter: /bin/bash: no such file or directory
```

This happens because the shell script makes the assumption that I have bash installed at `/bin/bash`, which is not the case on some distros (e.g. NixOS). This PR changes the shebangs in this project to the more portable `#!/usr/bin/env bash`. See also https://en.wikipedia.org/wiki/Shebang_(Unix)#Portability