### PR TITLE
Avoid resolving empty folders

### DIFF
--- a/src/SMAPI/Framework/ModLoading/ModResolver.cs
+++ b/src/SMAPI/Framework/ModLoading/ModResolver.cs
@@ -178,6 +178,7 @@ namespace StardewModdingAPI.Framework.ModLoading
             string[] lateArray = modIdsToLoadLate.ToArray();
 
             return mods
+                .Where(mod => mod.FailReason is not null)
                 .OrderBy(mod =>
                 {
                     string id = mod.Manifest.UniqueID;

--- a/src/SMAPI/Framework/ModLoading/ModResolver.cs
+++ b/src/SMAPI/Framework/ModLoading/ModResolver.cs
@@ -178,10 +178,12 @@ namespace StardewModdingAPI.Framework.ModLoading
             string[] lateArray = modIdsToLoadLate.ToArray();
 
             return mods
-                .Where(mod => mod.FailReason is not null)
                 .OrderBy(mod =>
                 {
-                    string id = mod.Manifest.UniqueID;
+                    string? id = mod.Manifest?.UniqueID;
+
+                    if (id is null)
+                        return 0;
 
                     if (modIdsToLoadEarly.TryGetValue(id, out string? actualId))
                         return -int.MaxValue + Array.IndexOf(earlyArray, actualId);

--- a/src/SMAPI/Framework/SCore.cs
+++ b/src/SMAPI/Framework/SCore.cs
@@ -433,7 +433,7 @@ namespace StardewModdingAPI.Framework
                 // apply load order customizations
                 if (this.Settings.ModsToLoadEarly.Any() || this.Settings.ModsToLoadLate.Any())
                 {
-                    HashSet<string> installedIds = new HashSet<string>(mods.Select(p => p.Manifest.UniqueID), StringComparer.OrdinalIgnoreCase);
+                    HashSet<string> installedIds = new HashSet<string>(mods.Where(p => p.FailReason is null).Select(p => p.Manifest.UniqueID), StringComparer.OrdinalIgnoreCase);
 
                     string[] missingEarlyMods = this.Settings.ModsToLoadEarly.Where(id => !installedIds.Contains(id)).OrderBy(p => p, StringComparer.OrdinalIgnoreCase).ToArray();
                     string[] missingLateMods = this.Settings.ModsToLoadLate.Where(id => !installedIds.Contains(id)).OrderBy(p => p, StringComparer.OrdinalIgnoreCase).ToArray();


### PR DESCRIPTION
tl;dr the modsToLoadEarly/modsToLoadLate weren't excluding mods that didn't load, leading to null references like so: https://smapi.io/log/ca072e943a4f488c82be1e9c9341d6c9

For an example, see the repo pack below. (just move the config file to smapi-internal)
[Mods.zip](https://github.com/Pathoschild/SMAPI/files/11057843/Mods.zip)

![image](https://user-images.githubusercontent.com/94934860/227406232-17d5c9fc-9fee-426e-9fda-2b43948dfd12.png)

