### PR TITLE
Fix examples field in manifest schema

### DIFF
--- a/src/SMAPI.Web/wwwroot/schemas/manifest.json
+++ b/src/SMAPI.Web/wwwroot/schemas/manifest.json
@@ -43,7 +43,7 @@
             "description": "The DLL filename SMAPI should load for this mod. Mutually exclusive with ContentPackFor.",
             "type": "string",
             "pattern": "^[a-zA-Z0-9_.-]+\\.dll$",
-            "examples": "LookupAnything.dll",
+            "examples": ["LookupAnything.dll"],
             "@errorMessages": {
                 "pattern": "Invalid value; must be a filename ending with .dll."
             }


### PR DESCRIPTION
VS is complaining that this line should be an array.

e.g.:

```
There are problems with this document's schema impacting one or more items in the document. Please report this issue to schema owner.

    Value must be one of the following types: array
    at (line 46, column 13) in document https://smapi.io/schemas/manifest.json
    at schema text "examples"
```
