### PR TITLE
Fix log parser no longer ignoring Error Handler on Android

### DIFF
--- a/src/SMAPI.Web/Views/LogParser/Index.cshtml
+++ b/src/SMAPI.Web/Views/LogParser/Index.cshtml
@@ -248,7 +248,7 @@ else if (log?.IsValid == true)
         {
             <h2>Suggested fixes</h2>
             <ul id="fix-list">
-                @if (errorHandler is null && log.ApiVersionParsed?.IsNewerThan("3.8.4") is true)
+                @if (errorHandler is null && !log.GameVersion.ToLower().Contains("Android Unix"))
                 {
                     <li class="important">You don't have the <strong>Error Handler</strong> mod installed. This automatically prevents many game or mod errors. You can <a href="https://stardewvalleywiki.com/Modding:Player_Guide#Install_SMAPI">reinstall SMAPI</a> to re-add it.</li>
                 }


### PR DESCRIPTION
As versions have been updated, it's now required to check the platform name before ignoring EH. (Hopefully this is all valid, IntelliSense wasn't working so had to guess on most things)
