### PR TITLE
Add doors to the warps-changed tracking in map asset propagation

### DIFF
--- a/src/SMAPI/Metadata/CoreAssetPropagator.cs
+++ b/src/SMAPI/Metadata/CoreAssetPropagator.cs
@@ -203,9 +203,14 @@ namespace StardewModdingAPI.Metadata
                         {
                             static ISet<string> GetWarpSet(GameLocation location)
                             {
-                                return new HashSet<string>(
+                                HashSet<string> ret =  new HashSet<string>(
                                     location.warps.Select(p => p.TargetName)
                                 );
+
+                                if (location.doors?.Count() is not null or 0)
+                                    foreach (var door in location.doors.Values)
+                                        ret.Add(door);
+                                return ret;
                             }
 
                             var oldWarps = GetWarpSet(location);


### PR DESCRIPTION
Currently, doors are ignored by the code that checks to see if the macro pathfinding cache needs to be refreshed. As NPCs can still use doors, this causes npcs to path weirdly.

(Was helping Dodo debug a schedule. East Scarpe has a place where a door warp only exists on certain days, and if he loaded the game on that day, Rodney pathed correctly. If he slept into the day, Rodney couldn't find the warp.)