### PR TITLE
Implement the InterpolatedStringHandler pattern for verbose logging

### DIFF
--- a/src/SMAPI/Framework/Logging/VerboseLogStringHandler.cs
+++ b/src/SMAPI/Framework/Logging/VerboseLogStringHandler.cs
@@ -8,7 +8,8 @@ namespace StardewModdingAPI.Framework.Logging;
 [InterpolatedStringHandler]
 public ref struct VerboseLogStringHandler
 {
-    private readonly DefaultInterpolatedStringHandler _handler;
+    /// <summary>The underlying interpolated string handler.</summary>
+    private DefaultInterpolatedStringHandler _handler;
 
     /// <summary>
     /// Construct an instance.

--- a/src/SMAPI/Framework/Logging/VerboseLogStringHandler.cs
+++ b/src/SMAPI/Framework/Logging/VerboseLogStringHandler.cs
@@ -1,51 +1,50 @@
 using System.Runtime.CompilerServices;
 
-namespace StardewModdingAPI.Framework.Logging;
-
-/// <summary>
-/// An interpolated string handler to handle verbose logging.
-/// </summary>
-[InterpolatedStringHandler]
-public ref struct VerboseLogStringHandler
+namespace StardewModdingAPI.Framework.Logging
 {
-    /// <summary>The underlying interpolated string handler.</summary>
-    private DefaultInterpolatedStringHandler _handler;
-
-    /// <summary>
-    /// Construct an instance.
-    /// </summary>
-    /// <param name="literalLength">The total length of literals used in interpolation.</param>
-    /// <param name="formattedCount">The number of interpolation holes to fill.</param>
-    /// <param name="monitor">The monitor instance.</param>
-    /// <param name="isValid">Whether or not </param>
-    public VerboseLogStringHandler(int literalLength, int formattedCount, IMonitor monitor, out bool isValid)
+    /// <summary>An interpolated string handler to handle verbose logging.</summary>
+    [InterpolatedStringHandler]
+    public ref struct VerboseLogStringHandler
     {
-        if (monitor.IsVerbose)
+        /*********
+        ** Fields
+        *********/
+        /// <summary>The underlying interpolated string handler.</summary>
+        private DefaultInterpolatedStringHandler Handler;
+
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Construct an instance.</summary>
+        /// <param name="literalLength">The total length of literals used in interpolation.</param>
+        /// <param name="formattedCount">The number of interpolation holes to fill.</param>
+        /// <param name="monitor">The monitor instance.</param>
+        /// <param name="isValid">Whether the handler can receive and output data.</param>
+        public VerboseLogStringHandler(int literalLength, int formattedCount, IMonitor monitor, out bool isValid)
         {
-            this._handler = new(literalLength, formattedCount);
-            isValid = true;
-            return;
+            isValid = monitor.IsVerbose;
+
+            if (isValid)
+                this.Handler = new(literalLength, formattedCount);
         }
 
-        isValid = false;
-        this._handler = default;
-    }
+        /// <inheritdoc cref="DefaultInterpolatedStringHandler.AppendLiteral(string)"/>
+        public void AppendLiteral(string literal)
+        {
+            this.Handler.AppendLiteral(literal);
+        }
 
-    /// <inheritdoc cref="DefaultInterpolatedStringHandler.AppendLiteral(string)"/>
-    public void AppendLiteral(string literal)
-    {
-        this._handler.AppendLiteral(literal);
-    }
+        /// <inheritdoc cref="DefaultInterpolatedStringHandler.AppendFormatted{T}(T)"/>
+        public void AppendFormatted<T>(T value)
+        {
+            this.Handler.AppendFormatted(value);
+        }
 
-    /// <inheritdoc cref="DefaultInterpolatedStringHandler.AppendFormatted{T}(T)"/>
-    public void AppendFormatted<T>(T value)
-    {
-        this._handler.AppendFormatted(value);
-    }
-
-    /// <inheritdoc />
-    public override string ToString()
-    {
-        return this._handler.ToStringAndClear();
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return this.Handler.ToStringAndClear();
+        }
     }
 }

--- a/src/SMAPI/Framework/Logging/VerboseLogStringHandler.cs
+++ b/src/SMAPI/Framework/Logging/VerboseLogStringHandler.cs
@@ -1,0 +1,50 @@
+using System.Runtime.CompilerServices;
+
+namespace StardewModdingAPI.Framework.Logging;
+
+/// <summary>
+/// An interpolated string handler to handle verbose logging.
+/// </summary>
+[InterpolatedStringHandler]
+public ref struct VerboseLogStringHandler
+{
+    private readonly DefaultInterpolatedStringHandler _handler;
+
+    /// <summary>
+    /// Construct an instance.
+    /// </summary>
+    /// <param name="literalLength">The total length of literals used in interpolation.</param>
+    /// <param name="formattedCount">The number of interpolation holes to fill.</param>
+    /// <param name="monitor">The monitor instance.</param>
+    /// <param name="isValid">Whether or not </param>
+    public VerboseLogStringHandler(int literalLength, int formattedCount, IMonitor monitor, out bool isValid)
+    {
+        if (monitor.IsVerbose)
+        {
+            this._handler = new(literalLength, formattedCount);
+            isValid = true;
+            return;
+        }
+
+        isValid = false;
+        this._handler = default;
+    }
+
+    /// <inheritdoc cref="DefaultInterpolatedStringHandler.AppendLiteral(string)"/>
+    public void AppendLiteral(string literal)
+    {
+        this._handler.AppendLiteral(literal);
+    }
+
+    /// <inheritdoc cref="DefaultInterpolatedStringHandler.AppendFormatted{T}(T)"/>
+    public void AppendFormatted<T>(T value)
+    {
+        this._handler.AppendFormatted(value);
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return this._handler.ToStringAndClear();
+    }
+}

--- a/src/SMAPI/Framework/Monitor.cs
+++ b/src/SMAPI/Framework/Monitor.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
-
 using StardewModdingAPI.Framework.Logging;
 using StardewModdingAPI.Internal.ConsoleWriting;
 
@@ -95,6 +94,7 @@ namespace StardewModdingAPI.Framework
                 this.Log(message);
         }
 
+        /// <inheritdoc />
         public void VerboseLog([InterpolatedStringHandlerArgument("")] ref VerboseLogStringHandler message)
         {
             if (this.IsVerbose)

--- a/src/SMAPI/Framework/Monitor.cs
+++ b/src/SMAPI/Framework/Monitor.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+
 using StardewModdingAPI.Framework.Logging;
 using StardewModdingAPI.Internal.ConsoleWriting;
 
@@ -25,7 +27,7 @@ namespace StardewModdingAPI.Framework
         private static readonly int MaxLevelLength = Enum.GetValues<LogLevel>().Max(level => level.ToString().Length);
 
         /// <summary>The cached representation for each level when added to a log header.</summary>
-        private static readonly Dictionary<ConsoleLogLevel, string> LogStrings = Enum.GetValues<ConsoleLogLevel>().ToDictionary(level => level, level => level.ToString().ToUpper().PadRight(Monitor.MaxLevelLength));
+        private static readonly Dictionary<ConsoleLogLevel, string> LogStrings = Enum.GetValues<ConsoleLogLevel>().ToDictionary(level => level, level => level.ToString().ToUpperInvariant().PadRight(Monitor.MaxLevelLength));
 
         /// <summary>A cache of messages that should only be logged once.</summary>
         private readonly HashSet<LogOnceCacheKey> LogOnceCache = new();
@@ -91,6 +93,12 @@ namespace StardewModdingAPI.Framework
         {
             if (this.IsVerbose)
                 this.Log(message);
+        }
+
+        public void VerboseLog([InterpolatedStringHandlerArgument("")] ref VerboseLogStringHandler message)
+        {
+            if (this.IsVerbose)
+                this.Log(message.ToString());
         }
 
         /// <summary>Write a newline to the console and log file.</summary>

--- a/src/SMAPI/IMonitor.cs
+++ b/src/SMAPI/IMonitor.cs
@@ -1,3 +1,7 @@
+using System.Runtime.CompilerServices;
+
+using StardewModdingAPI.Framework.Logging;
+
 namespace StardewModdingAPI
 {
     /// <summary>Encapsulates monitoring and logging for a given module.</summary>
@@ -26,5 +30,9 @@ namespace StardewModdingAPI
         /// <summary>Log a message that only appears when <see cref="IsVerbose"/> is enabled.</summary>
         /// <param name="message">The message to log.</param>
         void VerboseLog(string message);
+
+        /// <summary>Log a message that only appears when <see cref="IsVerbose"/> is enabled.</summary>
+        /// <param name="message">The message to log.</param>
+        void VerboseLog([InterpolatedStringHandlerArgument("")] ref VerboseLogStringHandler message);
     }
 }

--- a/src/SMAPI/IMonitor.cs
+++ b/src/SMAPI/IMonitor.cs
@@ -1,5 +1,4 @@
 using System.Runtime.CompilerServices;
-
 using StardewModdingAPI.Framework.Logging;
 
 namespace StardewModdingAPI


### PR DESCRIPTION
Hi Pathos!

This is just a quick little pull request that implements the new-to-net-6 InterpolatedStringHandler pattern for verbose logging. This way, `.Monitor.VerboseLog($"any string interpolation {whatever}"}` won't have the string interpolation evaluated UNLESS verbose logging is enabled.

It's fully backwards compatible and will require no changes from mod authors. If a mod isn't recompiled for this change, it'll just use the string overload, and if the mod is recompiled, it'll automatically switch over to using the InterpolatedStringHandler version.

One possible downside: this technically changes the behavior when a log message also has mutation built into it. (ie `.Monitor.VerboseLog($"why {i++}")` will no longer see `i` increment.) 

Example log: https://smapi.io/log/4cf6b096effc4d10ae629124b42da742?Levels=trace%7Edebug%7Einfo%7Ewarn%7Eerror%7Ealert%7Ecritical&Page=2&PerPage=1000