### PR TITLE
Private assemblies via custom AssemblyLoadContext

### DIFF
--- a/src/SMAPI.Tests/Core/ModResolverTests.cs
+++ b/src/SMAPI.Tests/Core/ModResolverTests.cs
@@ -528,6 +528,7 @@ namespace SMAPI.Tests.Core
                 minimumApiVersion: minimumApiVersion != null ? new SemanticVersion(minimumApiVersion) : null,
                 minimumGameVersion: minimumGameVersion != null ? new SemanticVersion(minimumGameVersion) : null,
                 dependencies: dependencies ?? Array.Empty<IManifestDependency>(),
+                privateAssemblies: Array.Empty<string>(),
                 updateKeys: Array.Empty<string>()
             );
         }

--- a/src/SMAPI.Tests/Core/ModResolverTests.cs
+++ b/src/SMAPI.Tests/Core/ModResolverTests.cs
@@ -528,7 +528,7 @@ namespace SMAPI.Tests.Core
                 minimumApiVersion: minimumApiVersion != null ? new SemanticVersion(minimumApiVersion) : null,
                 minimumGameVersion: minimumGameVersion != null ? new SemanticVersion(minimumGameVersion) : null,
                 dependencies: dependencies ?? Array.Empty<IManifestDependency>(),
-                privateAssemblies: Array.Empty<string>(),
+                privateAssemblies: Array.Empty<IManifestPrivateAssembly>(),
                 updateKeys: Array.Empty<string>()
             );
         }

--- a/src/SMAPI.Toolkit.CoreInterfaces/IManifest.cs
+++ b/src/SMAPI.Toolkit.CoreInterfaces/IManifest.cs
@@ -38,6 +38,9 @@ namespace StardewModdingAPI
         /// <summary>The other mods that must be loaded before this mod.</summary>
         IManifestDependency[] Dependencies { get; }
 
+        /// <summary>The names of assemblies that should be private to this mod. These assemblies will not be directly accessible by other mods and will be ignored when a mod tries to use an assembly with the same name in a public manner.</summary>
+        string[] PrivateAssemblies { get; }
+
         /// <summary>The namespaced mod IDs to query for updates (like <c>Nexus:541</c>).</summary>
         string[] UpdateKeys { get; }
 

--- a/src/SMAPI.Toolkit.CoreInterfaces/IManifest.cs
+++ b/src/SMAPI.Toolkit.CoreInterfaces/IManifest.cs
@@ -38,7 +38,7 @@ namespace StardewModdingAPI
         /// <summary>The other mods that must be loaded before this mod.</summary>
         IManifestDependency[] Dependencies { get; }
 
-        /// <summary>The assemblies which should only be loaded for the current mod. These won't be directly accessible by other mods, and will be ignored when another mod tries to use assemblies with the same names.</summary>
+        /// <summary>The assemblies in the mod folder which should only be referenced by this mod. These will be ignored when another mod tries to use assemblies with the same names.</summary>
         IManifestPrivateAssembly[] PrivateAssemblies { get; }
 
         /// <summary>The namespaced mod IDs to query for updates (like <c>Nexus:541</c>).</summary>

--- a/src/SMAPI.Toolkit.CoreInterfaces/IManifest.cs
+++ b/src/SMAPI.Toolkit.CoreInterfaces/IManifest.cs
@@ -38,8 +38,8 @@ namespace StardewModdingAPI
         /// <summary>The other mods that must be loaded before this mod.</summary>
         IManifestDependency[] Dependencies { get; }
 
-        /// <summary>The names of assemblies that should be private to this mod. These assemblies will not be directly accessible by other mods and will be ignored when a mod tries to use an assembly with the same name in a public manner.</summary>
-        string[] PrivateAssemblies { get; }
+        /// <summary>The assemblies which should only be loaded for the current mod. These won't be directly accessible by other mods, and will be ignored when another mod tries to use assemblies with the same names.</summary>
+        IManifestPrivateAssembly[] PrivateAssemblies { get; }
 
         /// <summary>The namespaced mod IDs to query for updates (like <c>Nexus:541</c>).</summary>
         string[] UpdateKeys { get; }

--- a/src/SMAPI.Toolkit.CoreInterfaces/IManifestPrivateAssembly.cs
+++ b/src/SMAPI.Toolkit.CoreInterfaces/IManifestPrivateAssembly.cs
@@ -1,12 +1,12 @@
 namespace StardewModdingAPI
 {
-    /// <summary>An assembly which is only loaded for the current mod. This won't be directly accessible by other mods, and will be ignored when another mod tries to use an assembly with the same name.</summary>
+    /// <summary>An assembly which should only be referenced by the current mod. It will be ignored when another mod tries to use an assembly with the same name.</summary>
     public interface IManifestPrivateAssembly
     {
-        /// <summary>The assembly name without the extension, like 'StardewModdingAPI'.</summary>
+        /// <summary>The assembly name without metadata, like 'Newtonsoft.Json'.</summary>
         public string Name { get; }
 
-        /// <summary>Whether to disable warnings that an assembly appears to be unused, e.g. because it's accessed via reflection.</summary>
+        /// <summary>Whether to disable warnings that an assembly seems to be unused, e.g. because it's accessed via reflection.</summary>
         public bool UsedDynamically { get; }
     }
 }

--- a/src/SMAPI.Toolkit.CoreInterfaces/IManifestPrivateAssembly.cs
+++ b/src/SMAPI.Toolkit.CoreInterfaces/IManifestPrivateAssembly.cs
@@ -1,0 +1,12 @@
+namespace StardewModdingAPI
+{
+    /// <summary>An assembly which is only loaded for the current mod. This won't be directly accessible by other mods, and will be ignored when another mod tries to use an assembly with the same name.</summary>
+    public interface IManifestPrivateAssembly
+    {
+        /// <summary>The assembly name without the extension, like 'StardewModdingAPI'.</summary>
+        public string Name { get; }
+
+        /// <summary>Whether to disable warnings that an assembly appears to be unused, e.g. because it's accessed via reflection.</summary>
+        public bool UsedDynamically { get; }
+    }
+}

--- a/src/SMAPI.Toolkit/Framework/ManifestValidator.cs
+++ b/src/SMAPI.Toolkit/Framework/ManifestValidator.cs
@@ -80,7 +80,7 @@ namespace StardewModdingAPI.Toolkit.Framework
             // validate dependency format
             foreach (IManifestDependency? dependency in manifest.Dependencies)
             {
-                if (dependency == null)
+                if (dependency is null)
                 {
                     error = $"manifest has a null entry under {nameof(IManifest.Dependencies)}.";
                     return false;
@@ -95,6 +95,28 @@ namespace StardewModdingAPI.Toolkit.Framework
                 if (!PathUtilities.IsSlug(dependency.UniqueID))
                 {
                     error = $"manifest has a {nameof(IManifest.Dependencies)} entry with an invalid {nameof(IManifestDependency.UniqueID)} field (IDs must only contain letters, numbers, underscores, periods, or hyphens).";
+                    return false;
+                }
+            }
+
+            // validate private assemblies format
+            foreach (IManifestPrivateAssembly? assembly in manifest.PrivateAssemblies)
+            {
+                if (assembly is null)
+                {
+                    error = $"manifest has a null entry under {nameof(IManifest.PrivateAssemblies)}.";
+                    return false;
+                }
+
+                if (string.IsNullOrWhiteSpace(assembly.Name))
+                {
+                    error = $"manifest has a {nameof(IManifest.PrivateAssemblies)} entry with no {nameof(IManifestPrivateAssembly.Name)} field.";
+                    return false;
+                }
+
+                if (assembly.Name.Contains('/') || assembly.Name.Contains('\\') || assembly.Name.Contains(".dll"))
+                {
+                    error = $"manifest has a {nameof(IManifest.PrivateAssemblies)} entry with an invalid {nameof(IManifestPrivateAssembly.Name)} field (must be the assembly name without the file path/extension).";
                     return false;
                 }
             }

--- a/src/SMAPI.Toolkit/Framework/ManifestValidator.cs
+++ b/src/SMAPI.Toolkit/Framework/ManifestValidator.cs
@@ -100,24 +100,41 @@ namespace StardewModdingAPI.Toolkit.Framework
             }
 
             // validate private assemblies format
-            foreach (IManifestPrivateAssembly? assembly in manifest.PrivateAssemblies)
+            if (!hasDll)
             {
-                if (assembly is null)
+                if (manifest.PrivateAssemblies.Length > 0)
                 {
-                    error = $"manifest has a null entry under {nameof(IManifest.PrivateAssemblies)}.";
+                    error = $"manifest includes {nameof(IManifest.PrivateAssemblies)}, which isn't valid for a content pack.";
                     return false;
                 }
-
-                if (string.IsNullOrWhiteSpace(assembly.Name))
+            }
+            else
+            {
+                foreach (IManifestPrivateAssembly? assembly in manifest.PrivateAssemblies)
                 {
-                    error = $"manifest has a {nameof(IManifest.PrivateAssemblies)} entry with no {nameof(IManifestPrivateAssembly.Name)} field.";
-                    return false;
-                }
+                    if (assembly is null)
+                    {
+                        error = $"manifest has a null entry under {nameof(IManifest.PrivateAssemblies)}.";
+                        return false;
+                    }
 
-                if (assembly.Name.Contains('/') || assembly.Name.Contains('\\') || assembly.Name.Contains(".dll"))
-                {
-                    error = $"manifest has a {nameof(IManifest.PrivateAssemblies)} entry with an invalid {nameof(IManifestPrivateAssembly.Name)} field (must be the assembly name without the file path/extension).";
-                    return false;
+                    if (string.IsNullOrWhiteSpace(assembly.Name))
+                    {
+                        error = $"manifest has a {nameof(IManifest.PrivateAssemblies)} entry with no {nameof(IManifestPrivateAssembly.Name)} field.";
+                        return false;
+                    }
+
+                    if (assembly.Name.Contains('/') || assembly.Name.Contains('\\') || assembly.Name.Contains(".dll"))
+                    {
+                        error = $"manifest has a {nameof(IManifest.PrivateAssemblies)} entry with an invalid {nameof(IManifestPrivateAssembly.Name)} field (must be the assembly name without the file path, extension, or metadata).";
+                        return false;
+                    }
+
+                    if (assembly.Name is "0Harmony" or "MonoGame.Framework" or "StardewModdingAPI" or "Stardew Valley" or "StardewValley.GameData")
+                    {
+                        error = $"manifest has a {nameof(IManifest.PrivateAssemblies)} entry with an invalid {nameof(IManifestPrivateAssembly.Name)} field (the '{assembly.Name}' assembly can't be private).";
+                        return false;
+                    }
                 }
             }
 

--- a/src/SMAPI.Toolkit/Serialization/Converters/ManifestPrivateAssemblyArrayConverter.cs
+++ b/src/SMAPI.Toolkit/Serialization/Converters/ManifestPrivateAssemblyArrayConverter.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using StardewModdingAPI.Toolkit.Serialization.Models;
+
+namespace StardewModdingAPI.Toolkit.Serialization.Converters
+{
+    /// <summary>Handles deserialization of <see cref="IManifestPrivateAssembly"/> arrays.</summary>
+    internal class ManifestPrivateAssemblyArrayConverter : JsonConverter
+    {
+        /*********
+        ** Accessors
+        *********/
+        /// <inheritdoc />
+        public override bool CanWrite => false;
+
+
+        /*********
+        ** Public methods
+        *********/
+        /// <inheritdoc />
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(ManifestPrivateAssembly[]);
+        }
+
+
+        /*********
+        ** Protected methods
+        *********/
+        /// <inheritdoc />
+        public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+        {
+            List<ManifestPrivateAssembly> result = new List<ManifestPrivateAssembly>();
+
+            foreach (JObject obj in JArray.Load(reader).Children<JObject>())
+            {
+                string name = obj.ValueIgnoreCase<string>(nameof(ManifestPrivateAssembly.Name))!; // will be validated separately if null
+                bool usedDynamically = obj.ValueIgnoreCase<bool?>(nameof(ManifestPrivateAssembly.UsedDynamically)) ?? false;
+                result.Add(new ManifestPrivateAssembly(name, usedDynamically));
+            }
+
+            return result.ToArray();
+        }
+
+        /// <inheritdoc />
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+        {
+            throw new InvalidOperationException("This converter does not write JSON.");
+        }
+    }
+}

--- a/src/SMAPI.Toolkit/Serialization/Models/Manifest.cs
+++ b/src/SMAPI.Toolkit/Serialization/Models/Manifest.cs
@@ -43,6 +43,9 @@ namespace StardewModdingAPI.Toolkit.Serialization.Models
         public IManifestDependency[] Dependencies { get; }
 
         /// <inheritdoc />
+        public string[] PrivateAssemblies { get; private set; }
+
+        /// <inheritdoc />
         public string[] UpdateKeys { get; private set; }
 
         /// <inheritdoc />
@@ -76,6 +79,7 @@ namespace StardewModdingAPI.Toolkit.Serialization.Models
                 contentPackFor: contentPackFor != null
                     ? new ManifestContentPackFor(contentPackFor, null)
                     : null,
+                privateAssemblies: null,
                 dependencies: null,
                 updateKeys: null
             )
@@ -92,9 +96,10 @@ namespace StardewModdingAPI.Toolkit.Serialization.Models
         /// <param name="entryDll">The name of the DLL in the directory that has the <c>Entry</c> method. Mutually exclusive with <see cref="ContentPackFor"/>.</param>
         /// <param name="contentPackFor">The modID which will read this as a content pack.</param>
         /// <param name="dependencies">The other mods that must be loaded before this mod.</param>
+        /// <param name="privateAssemblies">The names of assemblies that should be private to this mod. These assemblies will not be directly accessible by other mods and will be ignored when a mod tries to use an assembly with the same name in a public manner.</param>
         /// <param name="updateKeys">The namespaced mod IDs to query for updates (like <c>Nexus:541</c>).</param>
         [JsonConstructor]
-        public Manifest(string uniqueId, string name, string author, string description, ISemanticVersion version, ISemanticVersion? minimumApiVersion, ISemanticVersion? minimumGameVersion, string? entryDll, IManifestContentPackFor? contentPackFor, IManifestDependency[]? dependencies, string[]? updateKeys)
+        public Manifest(string uniqueId, string name, string author, string description, ISemanticVersion version, ISemanticVersion? minimumApiVersion, ISemanticVersion? minimumGameVersion, string? entryDll, IManifestContentPackFor? contentPackFor, IManifestDependency[]? dependencies, string[]? privateAssemblies, string[]? updateKeys)
         {
             this.UniqueID = this.NormalizeField(uniqueId);
             this.Name = this.NormalizeField(name, replaceSquareBrackets: true);
@@ -106,6 +111,7 @@ namespace StardewModdingAPI.Toolkit.Serialization.Models
             this.EntryDll = this.NormalizeField(entryDll);
             this.ContentPackFor = contentPackFor;
             this.Dependencies = dependencies ?? Array.Empty<IManifestDependency>();
+            this.PrivateAssemblies = privateAssemblies ?? Array.Empty<string>();
             this.UpdateKeys = updateKeys ?? Array.Empty<string>();
         }
 

--- a/src/SMAPI.Toolkit/Serialization/Models/Manifest.cs
+++ b/src/SMAPI.Toolkit/Serialization/Models/Manifest.cs
@@ -43,7 +43,8 @@ namespace StardewModdingAPI.Toolkit.Serialization.Models
         public IManifestDependency[] Dependencies { get; }
 
         /// <inheritdoc />
-        public string[] PrivateAssemblies { get; private set; }
+        [JsonConverter(typeof(ManifestPrivateAssemblyArrayConverter))]
+        public IManifestPrivateAssembly[] PrivateAssemblies { get; }
 
         /// <inheritdoc />
         public string[] UpdateKeys { get; private set; }
@@ -99,7 +100,7 @@ namespace StardewModdingAPI.Toolkit.Serialization.Models
         /// <param name="privateAssemblies">The names of assemblies that should be private to this mod. These assemblies will not be directly accessible by other mods and will be ignored when a mod tries to use an assembly with the same name in a public manner.</param>
         /// <param name="updateKeys">The namespaced mod IDs to query for updates (like <c>Nexus:541</c>).</param>
         [JsonConstructor]
-        public Manifest(string uniqueId, string name, string author, string description, ISemanticVersion version, ISemanticVersion? minimumApiVersion, ISemanticVersion? minimumGameVersion, string? entryDll, IManifestContentPackFor? contentPackFor, IManifestDependency[]? dependencies, string[]? privateAssemblies, string[]? updateKeys)
+        public Manifest(string uniqueId, string name, string author, string description, ISemanticVersion version, ISemanticVersion? minimumApiVersion, ISemanticVersion? minimumGameVersion, string? entryDll, IManifestContentPackFor? contentPackFor, IManifestDependency[]? dependencies, IManifestPrivateAssembly[]? privateAssemblies, string[]? updateKeys)
         {
             this.UniqueID = this.NormalizeField(uniqueId);
             this.Name = this.NormalizeField(name, replaceSquareBrackets: true);
@@ -111,7 +112,7 @@ namespace StardewModdingAPI.Toolkit.Serialization.Models
             this.EntryDll = this.NormalizeField(entryDll);
             this.ContentPackFor = contentPackFor;
             this.Dependencies = dependencies ?? Array.Empty<IManifestDependency>();
-            this.PrivateAssemblies = privateAssemblies ?? Array.Empty<string>();
+            this.PrivateAssemblies = privateAssemblies ?? Array.Empty<IManifestPrivateAssembly>();
             this.UpdateKeys = updateKeys ?? Array.Empty<string>();
         }
 
@@ -167,6 +168,16 @@ namespace StardewModdingAPI.Toolkit.Serialization.Models
             }
 
             return input;
+        }
+
+        /// <summary>Normalize whitespace in a raw string.</summary>
+        /// <param name="input">The input to strip.</param>
+#if NET6_0_OR_GREATER
+        [return: NotNullIfNotNull("input")]
+#endif
+        internal static string? NormalizeWhitespace(string? input)
+        {
+            return input?.Trim();
         }
     }
 }

--- a/src/SMAPI.Toolkit/Serialization/Models/ManifestContentPackFor.cs
+++ b/src/SMAPI.Toolkit/Serialization/Models/ManifestContentPackFor.cs
@@ -23,22 +23,8 @@ namespace StardewModdingAPI.Toolkit.Serialization.Models
         /// <param name="minimumVersion">The minimum required version (if any).</param>
         public ManifestContentPackFor(string uniqueId, ISemanticVersion? minimumVersion)
         {
-            this.UniqueID = this.NormalizeWhitespace(uniqueId);
+            this.UniqueID = Manifest.NormalizeWhitespace(uniqueId);
             this.MinimumVersion = minimumVersion;
-        }
-
-
-        /*********
-        ** Private methods
-        *********/
-        /// <summary>Normalize whitespace in a raw string.</summary>
-        /// <param name="input">The input to strip.</param>
-#if NET6_0_OR_GREATER
-        [return: NotNullIfNotNull("input")]
-#endif
-        private string? NormalizeWhitespace(string? input)
-        {
-            return input?.Trim();
         }
     }
 }

--- a/src/SMAPI.Toolkit/Serialization/Models/ManifestDependency.cs
+++ b/src/SMAPI.Toolkit/Serialization/Models/ManifestDependency.cs
@@ -43,23 +43,9 @@ namespace StardewModdingAPI.Toolkit.Serialization.Models
         [JsonConstructor]
         public ManifestDependency(string uniqueID, ISemanticVersion? minimumVersion, bool required = true)
         {
-            this.UniqueID = this.NormalizeWhitespace(uniqueID);
+            this.UniqueID = Manifest.NormalizeWhitespace(uniqueID);
             this.MinimumVersion = minimumVersion;
             this.IsRequired = required;
-        }
-
-
-        /*********
-        ** Private methods
-        *********/
-        /// <summary>Normalize whitespace in a raw string.</summary>
-        /// <param name="input">The input to strip.</param>
-#if NET6_0_OR_GREATER
-        [return: NotNullIfNotNull("input")]
-#endif
-        private string? NormalizeWhitespace(string? input)
-        {
-            return input?.Trim();
         }
     }
 }

--- a/src/SMAPI.Toolkit/Serialization/Models/ManifestPrivateAssembly.cs
+++ b/src/SMAPI.Toolkit/Serialization/Models/ManifestPrivateAssembly.cs
@@ -1,0 +1,28 @@
+namespace StardewModdingAPI.Toolkit.Serialization.Models
+{
+    /// <inheritdoc cref="IManifestPrivateAssembly" />
+    public class ManifestPrivateAssembly : IManifestPrivateAssembly
+    {
+        /*********
+        ** Accessors
+        *********/
+        /// <inheritdoc />
+        public string Name { get; }
+
+        /// <inheritdoc />
+        public bool UsedDynamically { get; }
+
+
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Construct an instance.</summary>
+        /// <param name="name">The assembly name.</param>
+        /// <param name="usedDynamically">Whether to disable warnings that an assembly appears to be unused, e.g. because it's accessed via reflection.</param>
+        public ManifestPrivateAssembly(string name, bool usedDynamically)
+        {
+            this.Name = Manifest.NormalizeWhitespace(name);
+            this.UsedDynamically = usedDynamically;
+        }
+    }
+}

--- a/src/SMAPI/Framework/ModLoading/AssemblyLoader.cs
+++ b/src/SMAPI/Framework/ModLoading/AssemblyLoader.cs
@@ -128,21 +128,12 @@ namespace StardewModdingAPI.Framework.ModLoading
             }
 
             // validate private assembly names
-            foreach (string rawName in mod.Manifest.PrivateAssemblies)
+            foreach (IManifestPrivateAssembly entry in mod.Manifest.PrivateAssemblies)
             {
-                string assemblyName = rawName;
+                string assemblyName = entry.Name;
 
-                bool isUsed;
-                if (assemblyName.EndsWith("!")) // a mod author can mark a private assembly with a trailing "!" - this will treat the assembly as used no matter what. useful for types loaded via reflection
-                {
-                    isUsed = true;
-                    assemblyName = assemblyName[..^1];
-                }
-                else
-                    isUsed = assemblies.Any(a => a.Definition?.Name.Name == assemblyName);
-
-                if (!isUsed)
-                    this.Monitor.Log($"      Mod {mod.DisplayName} specifies a private assembly {assemblyName}, but it does not use it.", LogLevel.Warn);
+                if (!entry.UsedDynamically && assemblies.All(a => a.Definition?.Name.Name != assemblyName))
+                    this.Monitor.Log($"      Mod '{mod.DisplayName}' refers to private assembly '{assemblyName}' in its manifest, but doesn't use it. This is a bug that should be reported to that mod's author.", LogLevel.Warn);
             }
 
             // validate load

--- a/src/SMAPI/Framework/ModLoading/AssemblyLoader.cs
+++ b/src/SMAPI/Framework/ModLoading/AssemblyLoader.cs
@@ -106,7 +106,7 @@ namespace StardewModdingAPI.Framework.ModLoading
         /// <param name="mod">The mod for which the assembly is being loaded.</param>
         /// <param name="assemblyFile">The assembly file.</param>
         /// <param name="assumeCompatible">Assume the mod is compatible, even if incompatible code is detected.</param>
-        /// <param name="assemblyLoadContext">The assembly load context for the mod currently being loaded.</param>
+        /// <param name="assemblyLoadContext">The assembly load context with which to load assemblies for the current mod.</param>
         /// <returns>Returns the rewrite metadata for the preprocessed assembly.</returns>
         /// <exception cref="IncompatibleInstructionException">An incompatible CIL instruction was found while rewriting the assembly.</exception>
         public Assembly Load(IModMetadata mod, FileInfo assemblyFile, bool assumeCompatible, ModAssemblyLoadContext assemblyLoadContext)
@@ -128,7 +128,7 @@ namespace StardewModdingAPI.Framework.ModLoading
                 assemblies = this.GetReferencedLocalAssemblies(assemblyFile, visitedAssemblyNames, this.AssemblyDefinitionResolver).ToArray();
             }
 
-            // validate private assembly names
+            // validate private assemblies
             foreach (IManifestPrivateAssembly entry in mod.Manifest.PrivateAssemblies)
             {
                 string assemblyName = entry.Name;

--- a/src/SMAPI/Framework/ModLoading/ModAssemblyLoadContext.cs
+++ b/src/SMAPI/Framework/ModLoading/ModAssemblyLoadContext.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace StardewModdingAPI.Framework.ModLoading
+{
+    /// <summary>An <see cref="AssemblyLoadContext"/> which redirects <see cref="Assembly"/> load requests if another mod already loaded a given assembly and marked it public.</summary>
+    internal class ModAssemblyLoadContext : AssemblyLoadContext
+    {
+        /// <summary>A mutable list of all of the mods' <see cref="AssemblyLoadContext"/>s, which <i>will include</i> this one.</summary>
+        private readonly IReadOnlyList<ModAssemblyLoadContext> AllModAssemblyLoadContexts;
+
+        /// <summary>A preprocessed list of all private assembly names handled by this <see cref="ModAssemblyLoadContext"/>.</summary>
+        internal readonly IReadOnlyList<string> PrivateAssemblyNames;
+
+        /// <summary>Construct an instance.</summary>
+        /// <param name="mod">The mod the <see cref="ModAssemblyLoadContext"/> is for.</param>
+        /// <param name="allModAssemblyLoadContexts">A mutable list of all of the mods' <see cref="AssemblyLoadContext"/>s, which <i>will include</i> this one.</param>
+        internal ModAssemblyLoadContext(IModMetadata mod, IReadOnlyList<ModAssemblyLoadContext> allModAssemblyLoadContexts) : base(mod.Manifest.UniqueID)
+        {
+            this.AllModAssemblyLoadContexts = allModAssemblyLoadContexts;
+
+            // a mod author can mark a private assembly with a trailing "!" - this will treat the assembly as used no matter what. useful for types loaded via reflection
+            this.PrivateAssemblyNames = mod.Manifest.PrivateAssemblies
+                .Select(name => name.EndsWith("!") ? name[..^1] : name)
+                .ToList();
+        }
+
+        /// <inheritdoc/>
+        protected override Assembly? Load(AssemblyName assemblyName)
+        {
+            // ignore unnamed assemblies
+            if (assemblyName.Name is null)
+                return base.Load(assemblyName);
+
+            // normally here we'd try to load the assembly from a file in the mod's folder, but we load all assemblies in AssemblyLoader
+            // maybe assembly rewriting and loading could be moved here at some point - it would help with assemblies only used via reflection, not that it happens too often, if ever
+
+            // use any assembly loaded by another mod, as long it's not private
+            foreach (ModAssemblyLoadContext context in this.AllModAssemblyLoadContexts)
+            {
+                if (context == this)
+                    continue;
+
+                Assembly? alreadyLoadedAssembly = context.Assemblies
+                    .Where(assembly => assembly.GetName().Name is string name && !context.PrivateAssemblyNames.Contains(name))
+                    .FirstOrDefault(assembly => assembly.GetName() == assemblyName);
+
+                if (alreadyLoadedAssembly is not null)
+                    return alreadyLoadedAssembly;
+            }
+
+            // fallback
+            return base.Load(assemblyName);
+        }
+    }
+}

--- a/src/SMAPI/Framework/ModLoading/ModAssemblyLoadContext.cs
+++ b/src/SMAPI/Framework/ModLoading/ModAssemblyLoadContext.cs
@@ -23,8 +23,7 @@ namespace StardewModdingAPI.Framework.ModLoading
         *********/
         /// <summary>Construct an instance.</summary>
         /// <param name="mod">The mod this context is for.</param>
-        /// <param name="modAssemblyLoadContexts">The assembly load contexts for all loaded mods, including this one.</param>
-        public ModAssemblyLoadContext(IModMetadata mod, IReadOnlyList<ModAssemblyLoadContext> modAssemblyLoadContexts)
+        public ModAssemblyLoadContext(IModMetadata mod)
             : base(mod.Manifest.UniqueID)
         {
             this.PrivateAssemblyNames = new HashSet<string>(mod.Manifest.PrivateAssemblies.Select(p => p.Name));

--- a/src/SMAPI/Framework/ModLoading/ModAssemblyLoadContext.cs
+++ b/src/SMAPI/Framework/ModLoading/ModAssemblyLoadContext.cs
@@ -5,7 +5,7 @@ using System.Runtime.Loader;
 
 namespace StardewModdingAPI.Framework.ModLoading
 {
-    /// <summary>An assembly load context which redirects assembly load requests if another mod already loaded a given assembly and marked it public.</summary>
+    /// <summary>An assembly load context which contains all the assemblies loaded by a particular mod, and redirects requests for public assemblies already loaded by another mod.</summary>
     internal class ModAssemblyLoadContext : AssemblyLoadContext
     {
         /*********
@@ -14,7 +14,7 @@ namespace StardewModdingAPI.Framework.ModLoading
         /// <summary>A lookup of public assembly names to the load context which contains them.</summary>
         private static readonly Dictionary<string, ModAssemblyLoadContext> LoadContextsByPublicAssemblyName = new();
 
-        /// <summary>A preprocessed list of private assembly names handled by this instance.</summary>
+        /// <summary>The list of private assembly names handled by this instance.</summary>
         private readonly HashSet<string> PrivateAssemblyNames;
 
 

--- a/src/SMAPI/Framework/ModLoading/ModAssemblyLoadContext.cs
+++ b/src/SMAPI/Framework/ModLoading/ModAssemblyLoadContext.cs
@@ -28,10 +28,7 @@ namespace StardewModdingAPI.Framework.ModLoading
             : base(mod.Manifest.UniqueID)
         {
             this.ModAssemblyLoadContexts = modAssemblyLoadContexts;
-            this.PrivateAssemblyNames = new HashSet<string>(
-                from assemblyName in mod.Manifest.PrivateAssemblies
-                select assemblyName.EndsWith("!") ? assemblyName[..^1] : assemblyName // a private assembly can be marked with a trailing "!" to treat it as used even if no usage was detected (e.g. access via reflection)
-            );
+            this.PrivateAssemblyNames = new HashSet<string>(mod.Manifest.PrivateAssemblies.Select(p => p.Name));
         }
 
 

--- a/src/SMAPI/Framework/SCore.cs
+++ b/src/SMAPI/Framework/SCore.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Reflection;
-using System.Runtime.Loader;
 using System.Security;
 using System.Text;
 using System.Threading;
@@ -1724,13 +1723,13 @@ namespace StardewModdingAPI.Framework
             {
                 // init
                 HashSet<string> suppressUpdateChecks = this.Settings.SuppressUpdateChecks;
-                List<ModAssemblyLoadContext> allModAssemblyLoadContexts = new List<ModAssemblyLoadContext>();
+                List<ModAssemblyLoadContext> modAssemblyLoadContexts = new();
                 IInterfaceProxyFactory proxyFactory = new InterfaceProxyFactory();
 
                 // load mods
                 foreach (IModMetadata mod in mods)
                 {
-                    if (!this.TryLoadMod(mod, mods, allModAssemblyLoadContexts, modAssemblyLoader, proxyFactory, jsonHelper, contentCore, modDatabase, suppressUpdateChecks, out ModFailReason? failReason, out string? errorPhrase, out string? errorDetails))
+                    if (!this.TryLoadMod(mod, mods, modAssemblyLoadContexts, modAssemblyLoader, proxyFactory, jsonHelper, contentCore, modDatabase, suppressUpdateChecks, out ModFailReason? failReason, out string? errorPhrase, out string? errorDetails))
                     {
                         mod.SetStatus(ModMetadataStatus.Failed, failReason.Value, errorPhrase, errorDetails);
                         skippedMods.Add(mod);
@@ -1807,7 +1806,7 @@ namespace StardewModdingAPI.Framework
         /// <summary>Load a given mod.</summary>
         /// <param name="mod">The mod to load.</param>
         /// <param name="mods">The mods being loaded.</param>
-        /// <param name="allModAssemblyLoadContexts">A mutable list of all of the mods' <see cref="AssemblyLoadContext"/>s, <i>excluding</i> the one for the currently being loaded mod - this method is responsible for creating and adding it to the list.</param>
+        /// <param name="modAssemblyLoadContexts">A mutable list of mods' assembly load contexts, <i>excluding</i> the one for the mod currently being loaded. This method is responsible for adding one to the list for the current mod.</param>
         /// <param name="assemblyLoader">Preprocesses and loads mod assemblies.</param>
         /// <param name="proxyFactory">Generates proxy classes to access mod APIs through an arbitrary interface.</param>
         /// <param name="jsonHelper">The JSON helper with which to read mods' JSON files.</param>
@@ -1818,7 +1817,7 @@ namespace StardewModdingAPI.Framework
         /// <param name="errorReasonPhrase">The user-facing reason phrase explaining why the mod couldn't be loaded (if applicable).</param>
         /// <param name="errorDetails">More detailed info about the error intended for developers (if any).</param>
         /// <returns>Returns whether the mod was successfully loaded.</returns>
-        private bool TryLoadMod(IModMetadata mod, IModMetadata[] mods, List<ModAssemblyLoadContext> allModAssemblyLoadContexts, AssemblyLoader assemblyLoader, IInterfaceProxyFactory proxyFactory, JsonHelper jsonHelper, ContentCoordinator contentCore, ModDatabase modDatabase, HashSet<string> suppressUpdateChecks, [NotNullWhen(false)] out ModFailReason? failReason, out string? errorReasonPhrase, out string? errorDetails)
+        private bool TryLoadMod(IModMetadata mod, IModMetadata[] mods, List<ModAssemblyLoadContext> modAssemblyLoadContexts, AssemblyLoader assemblyLoader, IInterfaceProxyFactory proxyFactory, JsonHelper jsonHelper, ContentCoordinator contentCore, ModDatabase modDatabase, HashSet<string> suppressUpdateChecks, [NotNullWhen(false)] out ModFailReason? failReason, out string? errorReasonPhrase, out string? errorDetails)
         {
             errorDetails = null;
 
@@ -1896,12 +1895,12 @@ namespace StardewModdingAPI.Framework
                 FileInfo assemblyFile = this.GetFileLookup(mod.DirectoryPath).GetFile(manifest.EntryDll!);
 
                 // load mod
-                ModAssemblyLoadContext modAssemblyLoadContext = new ModAssemblyLoadContext(mod, allModAssemblyLoadContexts);
+                ModAssemblyLoadContext modAssemblyLoadContext = new(mod, modAssemblyLoadContexts);
                 Assembly modAssembly;
                 try
                 {
                     modAssembly = assemblyLoader.Load(mod, assemblyFile, assumeCompatible: mod.DataRecord?.Status == ModStatus.AssumeCompatible, modAssemblyLoadContext);
-                    allModAssemblyLoadContexts.Add(modAssemblyLoadContext);
+                    modAssemblyLoadContexts.Add(modAssemblyLoadContext);
                     this.ModRegistry.TrackAssemblies(mod, modAssembly);
                 }
                 catch (IncompatibleInstructionException) // details already in trace logs

--- a/src/SMAPI/Framework/SCore.cs
+++ b/src/SMAPI/Framework/SCore.cs
@@ -1871,9 +1871,6 @@ namespace StardewModdingAPI.Framework
             // load as content pack
             if (mod.IsContentPack)
             {
-                if (manifest.PrivateAssemblies.Length != 0)
-                    this.Monitor.Log($"      Content pack specifies private assemblies, which is only valid for SMAPI mods.", LogLevel.Warn);
-
                 IMonitor monitor = this.LogManager.GetMonitor(manifest.UniqueID, mod.DisplayName);
                 IFileLookup fileLookup = this.GetFileLookup(mod.DirectoryPath);
                 GameContentHelper gameContentHelper = new(this.ContentCore, mod, mod.DisplayName, monitor, this.Reflection);
@@ -1895,7 +1892,7 @@ namespace StardewModdingAPI.Framework
                 FileInfo assemblyFile = this.GetFileLookup(mod.DirectoryPath).GetFile(manifest.EntryDll!);
 
                 // load mod
-                ModAssemblyLoadContext modAssemblyLoadContext = new(mod, modAssemblyLoadContexts);
+                ModAssemblyLoadContext modAssemblyLoadContext = new(mod);
                 Assembly modAssembly;
                 try
                 {

--- a/src/SMAPI/Framework/SCore.cs
+++ b/src/SMAPI/Framework/SCore.cs
@@ -1806,7 +1806,7 @@ namespace StardewModdingAPI.Framework
         /// <summary>Load a given mod.</summary>
         /// <param name="mod">The mod to load.</param>
         /// <param name="mods">The mods being loaded.</param>
-        /// <param name="modAssemblyLoadContexts">A mutable list of mods' assembly load contexts, <i>excluding</i> the one for the mod currently being loaded. This method is responsible for adding one to the list for the current mod.</param>
+        /// <param name="modAssemblyLoadContexts">The assembly load contexts containing assemblies loaded by mods, which should be updated with the context for the mod being loaded.</param>
         /// <param name="assemblyLoader">Preprocesses and loads mod assemblies.</param>
         /// <param name="proxyFactory">Generates proxy classes to access mod APIs through an arbitrary interface.</param>
         /// <param name="jsonHelper">The JSON helper with which to read mods' JSON files.</param>

--- a/src/SMAPI/Framework/SCore.cs
+++ b/src/SMAPI/Framework/SCore.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Reflection;
+using System.Runtime.Loader;
 using System.Security;
 using System.Text;
 using System.Threading;
@@ -1723,12 +1724,13 @@ namespace StardewModdingAPI.Framework
             {
                 // init
                 HashSet<string> suppressUpdateChecks = this.Settings.SuppressUpdateChecks;
+                List<ModAssemblyLoadContext> allModAssemblyLoadContexts = new List<ModAssemblyLoadContext>();
                 IInterfaceProxyFactory proxyFactory = new InterfaceProxyFactory();
 
                 // load mods
                 foreach (IModMetadata mod in mods)
                 {
-                    if (!this.TryLoadMod(mod, mods, modAssemblyLoader, proxyFactory, jsonHelper, contentCore, modDatabase, suppressUpdateChecks, out ModFailReason? failReason, out string? errorPhrase, out string? errorDetails))
+                    if (!this.TryLoadMod(mod, mods, allModAssemblyLoadContexts, modAssemblyLoader, proxyFactory, jsonHelper, contentCore, modDatabase, suppressUpdateChecks, out ModFailReason? failReason, out string? errorPhrase, out string? errorDetails))
                     {
                         mod.SetStatus(ModMetadataStatus.Failed, failReason.Value, errorPhrase, errorDetails);
                         skippedMods.Add(mod);
@@ -1805,6 +1807,7 @@ namespace StardewModdingAPI.Framework
         /// <summary>Load a given mod.</summary>
         /// <param name="mod">The mod to load.</param>
         /// <param name="mods">The mods being loaded.</param>
+        /// <param name="allModAssemblyLoadContexts">A mutable list of all of the mods' <see cref="AssemblyLoadContext"/>s, <i>excluding</i> the one for the currently being loaded mod - this method is responsible for creating and adding it to the list.</param>
         /// <param name="assemblyLoader">Preprocesses and loads mod assemblies.</param>
         /// <param name="proxyFactory">Generates proxy classes to access mod APIs through an arbitrary interface.</param>
         /// <param name="jsonHelper">The JSON helper with which to read mods' JSON files.</param>
@@ -1815,7 +1818,7 @@ namespace StardewModdingAPI.Framework
         /// <param name="errorReasonPhrase">The user-facing reason phrase explaining why the mod couldn't be loaded (if applicable).</param>
         /// <param name="errorDetails">More detailed info about the error intended for developers (if any).</param>
         /// <returns>Returns whether the mod was successfully loaded.</returns>
-        private bool TryLoadMod(IModMetadata mod, IModMetadata[] mods, AssemblyLoader assemblyLoader, IInterfaceProxyFactory proxyFactory, JsonHelper jsonHelper, ContentCoordinator contentCore, ModDatabase modDatabase, HashSet<string> suppressUpdateChecks, [NotNullWhen(false)] out ModFailReason? failReason, out string? errorReasonPhrase, out string? errorDetails)
+        private bool TryLoadMod(IModMetadata mod, IModMetadata[] mods, List<ModAssemblyLoadContext> allModAssemblyLoadContexts, AssemblyLoader assemblyLoader, IInterfaceProxyFactory proxyFactory, JsonHelper jsonHelper, ContentCoordinator contentCore, ModDatabase modDatabase, HashSet<string> suppressUpdateChecks, [NotNullWhen(false)] out ModFailReason? failReason, out string? errorReasonPhrase, out string? errorDetails)
         {
             errorDetails = null;
 
@@ -1869,6 +1872,9 @@ namespace StardewModdingAPI.Framework
             // load as content pack
             if (mod.IsContentPack)
             {
+                if (manifest.PrivateAssemblies.Length != 0)
+                    this.Monitor.Log($"      Content pack specifies private assemblies, which is only valid for SMAPI mods.", LogLevel.Warn);
+
                 IMonitor monitor = this.LogManager.GetMonitor(manifest.UniqueID, mod.DisplayName);
                 IFileLookup fileLookup = this.GetFileLookup(mod.DirectoryPath);
                 GameContentHelper gameContentHelper = new(this.ContentCore, mod, mod.DisplayName, monitor, this.Reflection);
@@ -1890,10 +1896,12 @@ namespace StardewModdingAPI.Framework
                 FileInfo assemblyFile = this.GetFileLookup(mod.DirectoryPath).GetFile(manifest.EntryDll!);
 
                 // load mod
+                ModAssemblyLoadContext modAssemblyLoadContext = new ModAssemblyLoadContext(mod, allModAssemblyLoadContexts);
                 Assembly modAssembly;
                 try
                 {
-                    modAssembly = assemblyLoader.Load(mod, assemblyFile, assumeCompatible: mod.DataRecord?.Status == ModStatus.AssumeCompatible);
+                    modAssembly = assemblyLoader.Load(mod, assemblyFile, assumeCompatible: mod.DataRecord?.Status == ModStatus.AssumeCompatible, modAssemblyLoadContext);
+                    allModAssemblyLoadContexts.Add(modAssemblyLoadContext);
                     this.ModRegistry.TrackAssemblies(mod, modAssembly);
                 }
                 catch (IncompatibleInstructionException) // details already in trace logs


### PR DESCRIPTION
Hey @Pathoschild.
This PR implements marking specific assemblies used by mods as "private", which forbids other mods from using them directly, but allows multiple assemblies named the same to co-exist. This is mostly useful for mods consuming the same Nuget packages but at different versions. Before this PR, such mods could potentially fail to load if the older library loaded first or if the newer library had breaking changes.
The developers of said mods can now specify the assemblies coming from these Nuget packages under a new `PrivateAssemblies` field in the `manifest.json`.

The PR also adds validations for this new manifest key. If a mod does not reference an assembly listed under `PrivateAssemblies`, a warning will be logged. Also, if a content pack lists any assembly under that field, a warning will be logged too (as this PR only makes sense for SMAPI mods, not content packs).
The unreferenced private assembly warning can be disabled for a given assembly by suffixing the name with a `!` - this is only really useful if the assembly is not used directly in the mod - so in the rare case of loading the assembly via reflection.

By default, this change is purely additive and opt-in, so there should be no breaking changes.
The loading code changed from using `Assembly` methods to `AssemblyLoadContext` ones, but it's pretty much the same change my other PR #891 did, which means stuff like mod rewriting and Edit-and-Continue are still working.
Types from private assemblies should still be usable via Pintail-powered APIs. Direct references to such types from other mods will throw an exception at runtime, but that's to be expected.

This PR makes my other PR #891 obsolete, so I will be closing it.