### PR TITLE
Uplift rewriters to handle inherited fields

### DIFF
--- a/src/SMAPI/Framework/ModLoading/Finders/ReferenceToMissingMemberFinder.cs
+++ b/src/SMAPI/Framework/ModLoading/Finders/ReferenceToMissingMemberFinder.cs
@@ -36,7 +36,7 @@ namespace StardewModdingAPI.Framework.ModLoading.Finders
             if (fieldRef != null && this.ShouldValidate(fieldRef.DeclaringType))
             {
                 FieldDefinition? target = fieldRef.Resolve();
-                if (target == null || target.HasConstant || target.DeclaringType.FullName != fieldRef.DeclaringType.FullName)
+                if (target == null || target.HasConstant || target.DeclaringType.Namespace != fieldRef.DeclaringType.Namespace || target.DeclaringType.Name != fieldRef.DeclaringType.Name)
                 {
                     this.MarkFlag(InstructionHandleResult.NotCompatible, $"reference to {fieldRef.DeclaringType.FullName}.{fieldRef.Name} (no such field)");
                     return false;

--- a/src/SMAPI/Framework/ModLoading/Finders/ReferenceToMissingMemberFinder.cs
+++ b/src/SMAPI/Framework/ModLoading/Finders/ReferenceToMissingMemberFinder.cs
@@ -36,7 +36,7 @@ namespace StardewModdingAPI.Framework.ModLoading.Finders
             if (fieldRef != null && this.ShouldValidate(fieldRef.DeclaringType))
             {
                 FieldDefinition? target = fieldRef.Resolve();
-                if (target == null || target.HasConstant)
+                if (target == null || target.HasConstant || target.DeclaringType.FullName != fieldRef.DeclaringType.FullName)
                 {
                     this.MarkFlag(InstructionHandleResult.NotCompatible, $"reference to {fieldRef.DeclaringType.FullName}.{fieldRef.Name} (no such field)");
                     return false;

--- a/src/SMAPI/Framework/ModLoading/Finders/ReferenceToMissingMemberFinder.cs
+++ b/src/SMAPI/Framework/ModLoading/Finders/ReferenceToMissingMemberFinder.cs
@@ -36,7 +36,7 @@ namespace StardewModdingAPI.Framework.ModLoading.Finders
             if (fieldRef != null && this.ShouldValidate(fieldRef.DeclaringType))
             {
                 FieldDefinition? target = fieldRef.Resolve();
-                if (target == null || target.HasConstant || target.DeclaringType.Namespace != fieldRef.DeclaringType.Namespace || target.DeclaringType.Name != fieldRef.DeclaringType.Name)
+                if (target == null || target.HasConstant || !RewriteHelper.HasSameNamespaceAndName(fieldRef.DeclaringType, target.DeclaringType))
                 {
                     this.MarkFlag(InstructionHandleResult.NotCompatible, $"reference to {fieldRef.DeclaringType.FullName}.{fieldRef.Name} (no such field)");
                     return false;

--- a/src/SMAPI/Framework/ModLoading/Framework/RewriteHelper.cs
+++ b/src/SMAPI/Framework/ModLoading/Framework/RewriteHelper.cs
@@ -173,6 +173,17 @@ namespace StardewModdingAPI.Framework.ModLoading.Framework
             return RewriteHelper.TypeDefinitionComparer.Equals(typeA, typeB);
         }
 
+        /// <summary>Get whether a type reference and definition have the same namespace and name. This does <strong>not</strong> guarantee they point to the same type due to generics.</summary>
+        /// <param name="typeReference">The type reference.</param>
+        /// <param name="typeDefinition">The type definition.</param>
+        /// <remarks>This avoids an issue where we can't compare <see cref="TypeReference.FullName"/> to <see cref="TypeReference.FullName"/> because of the different ways they handle generics (e.g. <c>List`1&lt;System.String&gt;</c> vs <c>List`1</c>).</remarks>
+        public static bool HasSameNamespaceAndName(TypeReference? typeReference, TypeDefinition? typeDefinition)
+        {
+            return
+                typeReference?.Namespace == typeDefinition?.Namespace
+                && typeReference?.Name == typeDefinition?.Name;
+        }
+
         /// <summary>Get whether a method definition matches the signature expected by a method reference.</summary>
         /// <param name="definition">The method definition.</param>
         /// <param name="reference">The method reference.</param>

--- a/src/SMAPI/Framework/ModLoading/Rewriters/HeuristicFieldRewriter.cs
+++ b/src/SMAPI/Framework/ModLoading/Rewriters/HeuristicFieldRewriter.cs
@@ -38,7 +38,7 @@ namespace StardewModdingAPI.Framework.ModLoading.Rewriters
 
             // skip if not broken
             FieldDefinition? fieldDefinition = fieldRef.Resolve();
-            if (fieldDefinition?.HasConstant == false && fieldDefinition?.DeclaringType.FullName == fieldRef.DeclaringType.FullName)
+            if (fieldDefinition?.HasConstant == false && RewriteHelper.HasSameNamespaceAndName(fieldRef.DeclaringType, fieldDefinition.DeclaringType))
                 return false;
 
             // rewrite if possible

--- a/src/SMAPI/Framework/ModLoading/Rewriters/HeuristicFieldRewriter.cs
+++ b/src/SMAPI/Framework/ModLoading/Rewriters/HeuristicFieldRewriter.cs
@@ -128,7 +128,7 @@ namespace StardewModdingAPI.Framework.ModLoading.Rewriters
             instruction.Operand = module.ImportReference(fieldDefinition);
             fieldRef.FieldType = fieldDefinition.FieldType;
 
-            this.Phrases.Add($"{fieldRef.DeclaringType.Name}.{fieldRef.Name} -> {fieldDefinition.DeclaringType.Name}.{fieldRef.Name} (field => inherited field)");
+            this.Phrases.Add($"{fieldRef.DeclaringType.Name}.{fieldRef.Name} -> {fieldDefinition.DeclaringType.Name}.{fieldRef.Name} (field now inherited)");
             return this.MarkRewritten();
         }
     }

--- a/src/SMAPI/Framework/ModLoading/Rewriters/HeuristicFieldRewriter.cs
+++ b/src/SMAPI/Framework/ModLoading/Rewriters/HeuristicFieldRewriter.cs
@@ -117,8 +117,9 @@ namespace StardewModdingAPI.Framework.ModLoading.Rewriters
             // If its not resolvable, don't rewrite
             if (fieldDefinition == null)
                 return false;
-            // If same they don't need rewriting
-            if (fieldRef.DeclaringType.FullName == fieldDefinition.DeclaringType.FullName)
+            // If same they don't need rewriting, avoidingFullName as fieldRef and fieldDefinition resolve generics differently
+            if (fieldRef.DeclaringType.Namespace == fieldDefinition.DeclaringType.Namespace &&
+                fieldRef.DeclaringType.Name == fieldDefinition.DeclaringType.Name)
                 return false;
             // If static, it is less intuitive that rewriting should happen
             if (instruction.OpCode != OpCodes.Ldfld)


### PR DESCRIPTION
This fixes mods like Loved Labels redux which was runtime failing due to InvalidFieldsException

FullName isn't used due to generics like NetPausableField, where One FullName will contain generics and the other won't.
![image](https://github.com/Pathoschild/SMAPI/assets/767456/63845654-e9e6-45f9-9737-938567111db3)


Before: https://smapi.io/log/6efdd09f9be4430391ea167c6fa35d43?Levels=trace%7Edebug%7Einfo%7Ewarn%7Eerror%7Ealert%7Ecritical&Page=3&PerPage=1000

After: https://smapi.io/log/8499c6b624474b73a98eb9e1d70119a0?Page=2&PerPage=1000