### PR TITLE
Add config schema generation

### DIFF
--- a/build/deploy-local-smapi.targets
+++ b/build/deploy-local-smapi.targets
@@ -22,6 +22,7 @@ This assumes `find-game-folder.targets` has already been imported and validated.
     <Copy SourceFiles="$(TargetDir)\SMAPI.config.json" DestinationFiles="$(GamePath)\smapi-internal\config.json" />
     <Copy SourceFiles="$(TargetDir)\SMAPI.metadata.json" DestinationFiles="$(GamePath)\smapi-internal\metadata.json" />
     <Copy SourceFiles="$(TargetDir)\Newtonsoft.Json.dll" DestinationFolder="$(GamePath)\smapi-internal" />
+    <Copy SourceFiles="$(TargetDir)\Newtonsoft.Json.Schema.dll" DestinationFolder="$(GamePath)\smapi-internal" />
     <Copy SourceFiles="$(TargetDir)\TMXTile.dll" DestinationFolder="$(GamePath)\smapi-internal" />
     <Copy SourceFiles="$(TargetDir)\Pintail.dll" DestinationFolder="$(GamePath)\smapi-internal" />
     <Copy SourceFiles="@(TranslationFiles)" DestinationFolder="$(GamePath)\smapi-internal\i18n" />

--- a/build/deploy-local-smapi.targets
+++ b/build/deploy-local-smapi.targets
@@ -22,7 +22,7 @@ This assumes `find-game-folder.targets` has already been imported and validated.
     <Copy SourceFiles="$(TargetDir)\SMAPI.config.json" DestinationFiles="$(GamePath)\smapi-internal\config.json" />
     <Copy SourceFiles="$(TargetDir)\SMAPI.metadata.json" DestinationFiles="$(GamePath)\smapi-internal\metadata.json" />
     <Copy SourceFiles="$(TargetDir)\Newtonsoft.Json.dll" DestinationFolder="$(GamePath)\smapi-internal" />
-    <Copy SourceFiles="$(TargetDir)\Newtonsoft.Json.Schema.dll" DestinationFolder="$(GamePath)\smapi-internal" />
+    <Copy SourceFiles="$(TargetDir)\NJsonSchema.dll" DestinationFolder="$(GamePath)\smapi-internal" />
     <Copy SourceFiles="$(TargetDir)\TMXTile.dll" DestinationFolder="$(GamePath)\smapi-internal" />
     <Copy SourceFiles="$(TargetDir)\Pintail.dll" DestinationFolder="$(GamePath)\smapi-internal" />
     <Copy SourceFiles="@(TranslationFiles)" DestinationFolder="$(GamePath)\smapi-internal\i18n" />

--- a/build/deploy-local-smapi.targets
+++ b/build/deploy-local-smapi.targets
@@ -21,8 +21,10 @@ This assumes `find-game-folder.targets` has already been imported and validated.
     <Copy SourceFiles="$(TargetDir)\$(TargetName).xml" DestinationFolder="$(GamePath)" />
     <Copy SourceFiles="$(TargetDir)\SMAPI.config.json" DestinationFiles="$(GamePath)\smapi-internal\config.json" />
     <Copy SourceFiles="$(TargetDir)\SMAPI.metadata.json" DestinationFiles="$(GamePath)\smapi-internal\metadata.json" />
+    <Copy SourceFiles="$(TargetDir)\Namotion.Reflection.dll" DestinationFolder="$(GamePath)\smapi-internal" />
     <Copy SourceFiles="$(TargetDir)\Newtonsoft.Json.dll" DestinationFolder="$(GamePath)\smapi-internal" />
     <Copy SourceFiles="$(TargetDir)\NJsonSchema.dll" DestinationFolder="$(GamePath)\smapi-internal" />
+    <Copy SourceFiles="$(TargetDir)\NJsonSchema.Annotations.dll" DestinationFolder="$(GamePath)\smapi-internal" />
     <Copy SourceFiles="$(TargetDir)\TMXTile.dll" DestinationFolder="$(GamePath)\smapi-internal" />
     <Copy SourceFiles="$(TargetDir)\Pintail.dll" DestinationFolder="$(GamePath)\smapi-internal" />
     <Copy SourceFiles="@(TranslationFiles)" DestinationFolder="$(GamePath)\smapi-internal\i18n" />

--- a/build/unix/prepare-install-package.sh
+++ b/build/unix/prepare-install-package.sh
@@ -134,7 +134,7 @@ for folder in ${folders[@]}; do
     cp -r "$smapiBin/i18n" "$bundlePath/smapi-internal"
 
     # bundle smapi-internal
-    for name in "0Harmony.dll" "0Harmony.xml" "Mono.Cecil.dll" "Mono.Cecil.Mdb.dll" "Mono.Cecil.Pdb.dll" "MonoMod.Common.dll" "Newtonsoft.Json.dll" "Pathoschild.Http.Client.dll" "Pintail.dll" "TMXTile.dll" "SMAPI.Toolkit.dll" "SMAPI.Toolkit.xml" "SMAPI.Toolkit.CoreInterfaces.dll" "SMAPI.Toolkit.CoreInterfaces.xml" "System.Net.Http.Formatting.dll"; do
+    for name in "0Harmony.dll" "0Harmony.xml" "Mono.Cecil.dll" "Mono.Cecil.Mdb.dll" "Mono.Cecil.Pdb.dll" "MonoMod.Common.dll" "Newtonsoft.Json.dll" "Newtonsoft.Json.Schema.dll" "Pathoschild.Http.Client.dll" "Pintail.dll" "TMXTile.dll" "SMAPI.Toolkit.dll" "SMAPI.Toolkit.xml" "SMAPI.Toolkit.CoreInterfaces.dll" "SMAPI.Toolkit.CoreInterfaces.xml" "System.Net.Http.Formatting.dll"; do
         cp "$smapiBin/$name" "$bundlePath/smapi-internal"
     done
 

--- a/build/unix/prepare-install-package.sh
+++ b/build/unix/prepare-install-package.sh
@@ -134,7 +134,7 @@ for folder in ${folders[@]}; do
     cp -r "$smapiBin/i18n" "$bundlePath/smapi-internal"
 
     # bundle smapi-internal
-    for name in "0Harmony.dll" "0Harmony.xml" "Mono.Cecil.dll" "Mono.Cecil.Mdb.dll" "Mono.Cecil.Pdb.dll" "MonoMod.Common.dll" "Newtonsoft.Json.dll" "Newtonsoft.Json.Schema.dll" "Pathoschild.Http.Client.dll" "Pintail.dll" "TMXTile.dll" "SMAPI.Toolkit.dll" "SMAPI.Toolkit.xml" "SMAPI.Toolkit.CoreInterfaces.dll" "SMAPI.Toolkit.CoreInterfaces.xml" "System.Net.Http.Formatting.dll"; do
+    for name in "0Harmony.dll" "0Harmony.xml" "Mono.Cecil.dll" "Mono.Cecil.Mdb.dll" "Mono.Cecil.Pdb.dll" "MonoMod.Common.dll" "Namotion.Reflection.dll" "Newtonsoft.Json.dll" "NJsonSchema.dll" "NJsonSchema.Annotations.dll" "Pathoschild.Http.Client.dll" "Pintail.dll" "TMXTile.dll" "SMAPI.Toolkit.dll" "SMAPI.Toolkit.xml" "SMAPI.Toolkit.CoreInterfaces.dll" "SMAPI.Toolkit.CoreInterfaces.xml" "System.Net.Http.Formatting.dll"; do
         cp "$smapiBin/$name" "$bundlePath/smapi-internal"
     done
 

--- a/build/windows/prepare-install-package.ps1
+++ b/build/windows/prepare-install-package.ps1
@@ -155,7 +155,7 @@ foreach ($folder in $folders) {
     cp -Recurse "$smapiBin/i18n" "$bundlePath/smapi-internal"
 
     # bundle smapi-internal
-    foreach ($name in @("0Harmony.dll", "0Harmony.xml", "Mono.Cecil.dll", "Mono.Cecil.Mdb.dll", "Mono.Cecil.Pdb.dll", "MonoMod.Common.dll", "Newtonsoft.Json.dll", "Newtonsoft.Json.Schema.dll", "Pathoschild.Http.Client.dll", "Pintail.dll", "TMXTile.dll", "SMAPI.Toolkit.dll", "SMAPI.Toolkit.xml", "SMAPI.Toolkit.CoreInterfaces.dll", "SMAPI.Toolkit.CoreInterfaces.xml", "System.Net.Http.Formatting.dll")) {
+    foreach ($name in @("0Harmony.dll", "0Harmony.xml", "Mono.Cecil.dll", "Mono.Cecil.Mdb.dll", "Mono.Cecil.Pdb.dll", "MonoMod.Common.dll", "Namotion.Reflection.dll", "Newtonsoft.Json.dll", "NJsonSchema.dll", "NJsonSchema.Annotations.dll", "Pathoschild.Http.Client.dll", "Pintail.dll", "TMXTile.dll", "SMAPI.Toolkit.dll", "SMAPI.Toolkit.xml", "SMAPI.Toolkit.CoreInterfaces.dll", "SMAPI.Toolkit.CoreInterfaces.xml", "System.Net.Http.Formatting.dll")) {
         cp "$smapiBin/$name" "$bundlePath/smapi-internal"
     }
 

--- a/build/windows/prepare-install-package.ps1
+++ b/build/windows/prepare-install-package.ps1
@@ -155,7 +155,7 @@ foreach ($folder in $folders) {
     cp -Recurse "$smapiBin/i18n" "$bundlePath/smapi-internal"
 
     # bundle smapi-internal
-    foreach ($name in @("0Harmony.dll", "0Harmony.xml", "Mono.Cecil.dll", "Mono.Cecil.Mdb.dll", "Mono.Cecil.Pdb.dll", "MonoMod.Common.dll", "Newtonsoft.Json.dll", "Pathoschild.Http.Client.dll", "Pintail.dll", "TMXTile.dll", "SMAPI.Toolkit.dll", "SMAPI.Toolkit.xml", "SMAPI.Toolkit.CoreInterfaces.dll", "SMAPI.Toolkit.CoreInterfaces.xml", "System.Net.Http.Formatting.dll")) {
+    foreach ($name in @("0Harmony.dll", "0Harmony.xml", "Mono.Cecil.dll", "Mono.Cecil.Mdb.dll", "Mono.Cecil.Pdb.dll", "MonoMod.Common.dll", "Newtonsoft.Json.dll", "Newtonsoft.Json.Schema.dll", "Pathoschild.Http.Client.dll", "Pintail.dll", "TMXTile.dll", "SMAPI.Toolkit.dll", "SMAPI.Toolkit.xml", "SMAPI.Toolkit.CoreInterfaces.dll", "SMAPI.Toolkit.CoreInterfaces.xml", "System.Net.Http.Formatting.dll")) {
         cp "$smapiBin/$name" "$bundlePath/smapi-internal"
     }
 

--- a/src/SMAPI.Toolkit/SMAPI.Toolkit.csproj
+++ b/src/SMAPI.Toolkit/SMAPI.Toolkit.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.15" />
     <PackageReference Include="Pathoschild.Http.FluentClient" Version="4.4.0" />
     <PackageReference Include="System.Management" Version="8.0.0" Condition="'$(OS)' == 'Windows_NT'" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" Condition="'$(OS)' == 'Windows_NT'" />

--- a/src/SMAPI.Toolkit/SMAPI.Toolkit.csproj
+++ b/src/SMAPI.Toolkit/SMAPI.Toolkit.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.15" />
+    <PackageReference Include="NJsonSchema" Version="11.0.1" />
     <PackageReference Include="Pathoschild.Http.FluentClient" Version="4.4.0" />
     <PackageReference Include="System.Management" Version="8.0.0" Condition="'$(OS)' == 'Windows_NT'" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" Condition="'$(OS)' == 'Windows_NT'" />

--- a/src/SMAPI.Toolkit/Serialization/JsonHelper.cs
+++ b/src/SMAPI.Toolkit/Serialization/JsonHelper.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Schema;
-using Newtonsoft.Json.Schema.Generation;
+using NJsonSchema;
 using StardewModdingAPI.Toolkit.Serialization.Converters;
 
 namespace StardewModdingAPI.Toolkit.Serialization
@@ -13,20 +11,6 @@ namespace StardewModdingAPI.Toolkit.Serialization
     /// <summary>Encapsulates SMAPI's JSON file parsing.</summary>
     public class JsonHelper
     {
-        /*********
-        ** Fields
-        *********/
-        /// <summary>The JSON schema generator to use when creating a schema file.</summary>
-        private readonly JSchemaGenerator SchemaGenerator = new();
-
-        /// <summary>The JSON settings to use when creating a schema file.</summary>
-        private readonly JSchemaWriterSettings SchemaWriterSettings = new()
-        {
-            Version = SchemaVersion.Draft2019_09,
-            ReferenceHandling = JSchemaWriterReferenceHandling.Never
-        };
-
-
         /*********
         ** Accessors
         *********/
@@ -61,7 +45,7 @@ namespace StardewModdingAPI.Toolkit.Serialization
         /// <exception cref="JsonReaderException">The file contains invalid JSON.</exception>
         public bool ReadJsonFileIfExists<TModel>(string fullPath,
 #if NET6_0_OR_GREATER
-            [NotNullWhen(true)]
+            [System.Diagnostics.CodeAnalysis.NotNullWhen(true)]
 #endif
             out TModel? result
         )
@@ -142,8 +126,8 @@ namespace StardewModdingAPI.Toolkit.Serialization
                 Directory.CreateDirectory(dir);
 
             // write file
-            JSchema schema = this.SchemaGenerator.Generate(typeof(TModel));
-            string json = schema.ToString(this.SchemaWriterSettings);
+            JsonSchema schema = JsonSchema.FromType<TModel>();
+            string json = schema.ToJson();
             File.WriteAllText(fullPath, json);
         }
 

--- a/src/SMAPI.Toolkit/Serialization/JsonHelper.cs
+++ b/src/SMAPI.Toolkit/Serialization/JsonHelper.cs
@@ -14,18 +14,25 @@ namespace StardewModdingAPI.Toolkit.Serialization
     public class JsonHelper
     {
         /*********
+        ** Fields
+        *********/
+        /// <summary>The JSON schema generator to use when creating a schema file.</summary>
+        private readonly JSchemaGenerator SchemaGenerator = new();
+
+        /// <summary>The JSON settings to use when creating a schema file.</summary>
+        private readonly JSchemaWriterSettings SchemaWriterSettings = new()
+        {
+            Version = SchemaVersion.Draft2019_09,
+            ReferenceHandling = JSchemaWriterReferenceHandling.Never
+        };
+
+
+        /*********
         ** Accessors
         *********/
         /// <summary>The JSON settings to use when serializing and deserializing files.</summary>
         public JsonSerializerSettings JsonSettings { get; } = JsonHelper.CreateDefaultSettings();
 
-        private readonly JSchemaGenerator _schemaGenerator = new();
-
-        private readonly JSchemaWriterSettings _schemaWriterSettings = new()
-        {
-            Version = SchemaVersion.Draft2019_09,
-            ReferenceHandling = JSchemaWriterReferenceHandling.Never
-        };
 
         /*********
         ** Public methods
@@ -109,9 +116,7 @@ namespace StardewModdingAPI.Toolkit.Serialization
                 throw new ArgumentException("The file path is empty or invalid.", nameof(fullPath));
 
             // create directory if needed
-            string dir = Path.GetDirectoryName(fullPath)!;
-            if (dir == null)
-                throw new ArgumentException("The file path is invalid.", nameof(fullPath));
+            string dir = Path.GetDirectoryName(fullPath) ?? throw new ArgumentException("The file path is invalid.", nameof(fullPath));
             if (!Directory.Exists(dir))
                 Directory.CreateDirectory(dir);
 
@@ -120,7 +125,7 @@ namespace StardewModdingAPI.Toolkit.Serialization
             File.WriteAllText(fullPath, json);
         }
 
-        /// <summary>Generate a schema and save to a JSON file.</summary>
+        /// <summary>Save a data model schema to a JSON file.</summary>
         /// <typeparam name="TModel">The model type.</typeparam>
         /// <param name="fullPath">The absolute file path.</param>
         /// <exception cref="InvalidOperationException">The given path is empty or invalid.</exception>
@@ -132,16 +137,14 @@ namespace StardewModdingAPI.Toolkit.Serialization
                 throw new ArgumentException("The file path is empty or invalid.", nameof(fullPath));
 
             // create directory if needed
-            string dir = Path.GetDirectoryName(fullPath)!;
-            if (dir == null)
-                throw new ArgumentException("The file path is invalid.", nameof(fullPath));
+            string dir = Path.GetDirectoryName(fullPath) ?? throw new ArgumentException("The file path is invalid.", nameof(fullPath));
             if (!Directory.Exists(dir))
                 Directory.CreateDirectory(dir);
 
-            JSchema schema = this._schemaGenerator.Generate(typeof(TModel));
-            string output = schema.ToString(this._schemaWriterSettings);
-
-            File.WriteAllText(fullPath, output);
+            // write file
+            JSchema schema = this.SchemaGenerator.Generate(typeof(TModel));
+            string json = schema.ToString(this.SchemaWriterSettings);
+            File.WriteAllText(fullPath, json);
         }
 
         /// <summary>Deserialize JSON text if possible.</summary>

--- a/src/SMAPI/Framework/ModHelpers/DataHelper.cs
+++ b/src/SMAPI/Framework/ModHelpers/DataHelper.cs
@@ -28,7 +28,7 @@ namespace StardewModdingAPI.Framework.ModHelpers
         /// <summary>Construct an instance.</summary>
         /// <param name="mod">The mod using this instance.</param>
         /// <param name="modFolderPath">The absolute path to the mod folder.</param>
-        /// <param name="jsonHelper">The absolute path to the mod folder.</param>
+        /// <param name="jsonHelper">Encapsulates SMAPI's JSON file parsing.</param>
         public DataHelper(IModMetadata mod, string modFolderPath, JsonHelper jsonHelper)
             : base(mod)
         {
@@ -67,19 +67,21 @@ namespace StardewModdingAPI.Framework.ModHelpers
                 File.Delete(path);
         }
 
-        /// <inheritdoc/>
-        public void WriteJsonSchemaFile<TModel>(string path, TModel data) where TModel : class
+        /// <inheritdoc />
+        public void WriteJsonSchemaFile<TModel>(string path)
+            where TModel : class
         {
             if (!PathUtilities.IsSafeRelativePath(path))
-                throw new InvalidOperationException($"You must call {nameof(IMod.Helper)}.{nameof(IModHelper.Data)}.{nameof(this.WriteJsonFile)} with a relative path (without directory climbing).");
+                throw new InvalidOperationException($"You must call {nameof(IMod.Helper)}.{nameof(IModHelper.Data)}.{nameof(this.WriteJsonSchemaFile)} with a relative path (without directory climbing).");
 
             path = Path.Combine(this.ModFolderPath, PathUtilities.NormalizePath(path));
+
             this.JsonHelper.WriteJsonSchemaFile<TModel>(path);
         }
 
         /****
-         ** Save file
-         ****/
+        ** Save file
+        ****/
         /// <inheritdoc />
         public TModel? ReadSaveData<TModel>(string key)
             where TModel : class

--- a/src/SMAPI/Framework/ModHelpers/DataHelper.cs
+++ b/src/SMAPI/Framework/ModHelpers/DataHelper.cs
@@ -67,9 +67,19 @@ namespace StardewModdingAPI.Framework.ModHelpers
                 File.Delete(path);
         }
 
+        /// <inheritdoc/>
+        public void WriteJsonSchemaFile<TModel>(string path, TModel data) where TModel : class
+        {
+            if (!PathUtilities.IsSafeRelativePath(path))
+                throw new InvalidOperationException($"You must call {nameof(IMod.Helper)}.{nameof(IModHelper.Data)}.{nameof(this.WriteJsonFile)} with a relative path (without directory climbing).");
+
+            path = Path.Combine(this.ModFolderPath, PathUtilities.NormalizePath(path));
+            this.JsonHelper.WriteJsonSchemaFile<TModel>(path);
+        }
+
         /****
-        ** Save file
-        ****/
+         ** Save file
+         ****/
         /// <inheritdoc />
         public TModel? ReadSaveData<TModel>(string key)
             where TModel : class

--- a/src/SMAPI/Framework/ModHelpers/ModHelper.cs
+++ b/src/SMAPI/Framework/ModHelpers/ModHelper.cs
@@ -11,8 +11,9 @@ namespace StardewModdingAPI.Framework.ModHelpers
         /*********
         ** Fields
         *********/
-        /// <summary>Whether to generate config.schema.json files.</summary>
-        private readonly bool _generateConfigSchemas;
+        /// <summary>Whether to generate a <c>config.schema.json</c> file based on the mod's config model when it's loaded or saved.</summary>
+        private readonly bool GenerateConfigSchema;
+
 
         /*********
         ** Accessors
@@ -71,10 +72,10 @@ namespace StardewModdingAPI.Framework.ModHelpers
         /// <param name="reflectionHelper">An API for accessing private game code.</param>
         /// <param name="multiplayer">Provides multiplayer utilities.</param>
         /// <param name="translationHelper">An API for reading translations stored in the mod's <c>i18n</c> folder.</param>
-        /// <param name="generateConfigSchemas">Whether to generate config.schema.json files.</param>
+        /// <param name="generateConfigSchema">Whether to generate a <c>config.schema.json</c> file based on the mod's config model when it's loaded or saved.</param>
         /// <exception cref="ArgumentNullException">An argument is null or empty.</exception>
         /// <exception cref="InvalidOperationException">The <paramref name="modDirectory"/> path does not exist on disk.</exception>
-        public ModHelper(IModMetadata mod, string modDirectory, Func<SInputState> currentInputState, IModEvents events, IGameContentHelper gameContentHelper, IModContentHelper modContentHelper, IContentPackHelper contentPackHelper, ICommandHelper commandHelper, IDataHelper dataHelper, IModRegistry modRegistry, IReflectionHelper reflectionHelper, IMultiplayerHelper multiplayer, ITranslationHelper translationHelper, bool generateConfigSchemas)
+        public ModHelper(IModMetadata mod, string modDirectory, Func<SInputState> currentInputState, IModEvents events, IGameContentHelper gameContentHelper, IModContentHelper modContentHelper, IContentPackHelper contentPackHelper, ICommandHelper commandHelper, IDataHelper dataHelper, IModRegistry modRegistry, IReflectionHelper reflectionHelper, IMultiplayerHelper multiplayer, ITranslationHelper translationHelper, bool generateConfigSchema)
             : base(mod)
         {
             // validate directory
@@ -96,7 +97,7 @@ namespace StardewModdingAPI.Framework.ModHelpers
             this.Multiplayer = multiplayer ?? throw new ArgumentNullException(nameof(multiplayer));
             this.Translation = translationHelper ?? throw new ArgumentNullException(nameof(translationHelper));
             this.Events = events;
-            this._generateConfigSchemas = generateConfigSchemas;
+            this.GenerateConfigSchema = generateConfigSchema;
         }
 
         /****
@@ -108,12 +109,6 @@ namespace StardewModdingAPI.Framework.ModHelpers
         {
             TConfig config = this.Data.ReadJsonFile<TConfig>("config.json") ?? new TConfig();
             this.WriteConfig(config); // create file or fill in missing fields
-
-            if (this._generateConfigSchemas)
-            {
-                this.WriteConfigSchema(config);
-            }
-
             return config;
         }
 
@@ -122,12 +117,9 @@ namespace StardewModdingAPI.Framework.ModHelpers
             where TConfig : class, new()
         {
             this.Data.WriteJsonFile("config.json", config);
-        }
 
-        private void WriteConfigSchema<TConfig>(TConfig config)
-            where TConfig : class, new()
-        {
-            this.Data.WriteJsonSchemaFile("config.schema.json", config);
+            if (this.GenerateConfigSchema)
+                this.Data.WriteJsonSchemaFile<TConfig>("config.schema.json");
         }
 
         /****

--- a/src/SMAPI/Framework/ModHelpers/ModHelper.cs
+++ b/src/SMAPI/Framework/ModHelpers/ModHelper.cs
@@ -9,6 +9,12 @@ namespace StardewModdingAPI.Framework.ModHelpers
     internal class ModHelper : BaseHelper, IModHelper, IDisposable
     {
         /*********
+        ** Fields
+        *********/
+        /// <summary>Whether to generate config.schema.json files.</summary>
+        private readonly bool _generateConfigSchemas;
+
+        /*********
         ** Accessors
         *********/
         /// <inheritdoc />
@@ -65,9 +71,10 @@ namespace StardewModdingAPI.Framework.ModHelpers
         /// <param name="reflectionHelper">An API for accessing private game code.</param>
         /// <param name="multiplayer">Provides multiplayer utilities.</param>
         /// <param name="translationHelper">An API for reading translations stored in the mod's <c>i18n</c> folder.</param>
+        /// <param name="generateConfigSchemas">Whether to generate config.schema.json files.</param>
         /// <exception cref="ArgumentNullException">An argument is null or empty.</exception>
         /// <exception cref="InvalidOperationException">The <paramref name="modDirectory"/> path does not exist on disk.</exception>
-        public ModHelper(IModMetadata mod, string modDirectory, Func<SInputState> currentInputState, IModEvents events, IGameContentHelper gameContentHelper, IModContentHelper modContentHelper, IContentPackHelper contentPackHelper, ICommandHelper commandHelper, IDataHelper dataHelper, IModRegistry modRegistry, IReflectionHelper reflectionHelper, IMultiplayerHelper multiplayer, ITranslationHelper translationHelper)
+        public ModHelper(IModMetadata mod, string modDirectory, Func<SInputState> currentInputState, IModEvents events, IGameContentHelper gameContentHelper, IModContentHelper modContentHelper, IContentPackHelper contentPackHelper, ICommandHelper commandHelper, IDataHelper dataHelper, IModRegistry modRegistry, IReflectionHelper reflectionHelper, IMultiplayerHelper multiplayer, ITranslationHelper translationHelper, bool generateConfigSchemas)
             : base(mod)
         {
             // validate directory
@@ -89,6 +96,7 @@ namespace StardewModdingAPI.Framework.ModHelpers
             this.Multiplayer = multiplayer ?? throw new ArgumentNullException(nameof(multiplayer));
             this.Translation = translationHelper ?? throw new ArgumentNullException(nameof(translationHelper));
             this.Events = events;
+            this._generateConfigSchemas = generateConfigSchemas;
         }
 
         /****
@@ -100,6 +108,12 @@ namespace StardewModdingAPI.Framework.ModHelpers
         {
             TConfig config = this.Data.ReadJsonFile<TConfig>("config.json") ?? new TConfig();
             this.WriteConfig(config); // create file or fill in missing fields
+
+            if (this._generateConfigSchemas)
+            {
+                this.WriteConfigSchema(config);
+            }
+
             return config;
         }
 
@@ -108,6 +122,12 @@ namespace StardewModdingAPI.Framework.ModHelpers
             where TConfig : class, new()
         {
             this.Data.WriteJsonFile("config.json", config);
+        }
+
+        private void WriteConfigSchema<TConfig>(TConfig config)
+            where TConfig : class, new()
+        {
+            this.Data.WriteJsonSchemaFile("config.schema.json", config);
         }
 
         /****

--- a/src/SMAPI/Framework/Models/SConfig.cs
+++ b/src/SMAPI/Framework/Models/SConfig.cs
@@ -26,7 +26,8 @@ namespace StardewModdingAPI.Framework.Models
             [nameof(RewriteMods)] = true,
             [nameof(FixHarmony)] = true,
             [nameof(UseCaseInsensitivePaths)] = Constants.Platform is Platform.Android or Platform.Linux,
-            [nameof(SuppressHarmonyDebugMode)] = true
+            [nameof(SuppressHarmonyDebugMode)] = true,
+            [nameof(GenerateConfigSchemas)] = false,
         };
 
         /// <summary>The default values for <see cref="SuppressUpdateChecks"/>, to log changes if different.</summary>
@@ -99,6 +100,8 @@ namespace StardewModdingAPI.Framework.Models
         /// <summary>The mod IDs SMAPI should load after any other mods.</summary>
         public HashSet<string> ModsToLoadLate { get; set; }
 
+        /// <summary>Whether to generate config.schema.json files for external tools like mod managers.</summary>
+        public bool GenerateConfigSchemas { get; set; }
 
         /********
         ** Public methods
@@ -122,7 +125,8 @@ namespace StardewModdingAPI.Framework.Models
         /// <param name="suppressUpdateChecks"><inheritdoc cref="SuppressUpdateChecks" path="/summary" /></param>
         /// <param name="modsToLoadEarly"><inheritdoc cref="ModsToLoadEarly" path="/summary" /></param>
         /// <param name="modsToLoadLate"><inheritdoc cref="ModsToLoadLate" path="/summary" /></param>
-        public SConfig(bool developerMode, bool? checkForUpdates, bool? listenForConsoleInput, bool? paranoidWarnings, bool? useBetaChannel, string gitHubProjectName, string webApiBaseUrl, string[]? verboseLogging, bool? rewriteMods, bool? fixHarmony, bool? useCaseInsensitivePaths, bool? logNetworkTraffic, bool? logTechnicalDetailsForBrokenMods, ColorSchemeConfig consoleColors, bool? suppressHarmonyDebugMode, string[]? suppressUpdateChecks, string[]? modsToLoadEarly, string[]? modsToLoadLate)
+        /// <param name="generateConfigSchemas"><inheritdoc cref="GenerateConfigSchemas" path="/summary" /></param>
+        public SConfig(bool developerMode, bool? checkForUpdates, bool? listenForConsoleInput, bool? paranoidWarnings, bool? useBetaChannel, string gitHubProjectName, string webApiBaseUrl, string[]? verboseLogging, bool? rewriteMods, bool? fixHarmony, bool? useCaseInsensitivePaths, bool? logNetworkTraffic, bool? logTechnicalDetailsForBrokenMods, ColorSchemeConfig consoleColors, bool? suppressHarmonyDebugMode, string[]? suppressUpdateChecks, string[]? modsToLoadEarly, string[]? modsToLoadLate, bool? generateConfigSchemas)
         {
             this.DeveloperMode = developerMode;
             this.CheckForUpdates = checkForUpdates ?? (bool)SConfig.DefaultValues[nameof(this.CheckForUpdates)];
@@ -142,6 +146,7 @@ namespace StardewModdingAPI.Framework.Models
             this.SuppressUpdateChecks = new HashSet<string>(suppressUpdateChecks ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
             this.ModsToLoadEarly = new HashSet<string>(modsToLoadEarly ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
             this.ModsToLoadLate = new HashSet<string>(modsToLoadLate ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+            this.GenerateConfigSchemas = generateConfigSchemas ?? (bool)SConfig.DefaultValues[nameof(this.GenerateConfigSchemas)];
         }
 
         /// <summary>Override the value of <see cref="DeveloperMode"/>.</summary>

--- a/src/SMAPI/Framework/Models/SConfig.cs
+++ b/src/SMAPI/Framework/Models/SConfig.cs
@@ -27,7 +27,7 @@ namespace StardewModdingAPI.Framework.Models
             [nameof(FixHarmony)] = true,
             [nameof(UseCaseInsensitivePaths)] = Constants.Platform is Platform.Android or Platform.Linux,
             [nameof(SuppressHarmonyDebugMode)] = true,
-            [nameof(GenerateConfigSchemas)] = false,
+            [nameof(GenerateConfigSchemas)] = false
         };
 
         /// <summary>The default values for <see cref="SuppressUpdateChecks"/>, to log changes if different.</summary>
@@ -100,8 +100,9 @@ namespace StardewModdingAPI.Framework.Models
         /// <summary>The mod IDs SMAPI should load after any other mods.</summary>
         public HashSet<string> ModsToLoadLate { get; set; }
 
-        /// <summary>Whether to generate config.schema.json files for external tools like mod managers.</summary>
+        /// <summary>Whether to generate <c>config.schema.json</c> files for external tools like mod managers.</summary>
         public bool GenerateConfigSchemas { get; set; }
+
 
         /********
         ** Public methods

--- a/src/SMAPI/Framework/SCore.cs
+++ b/src/SMAPI/Framework/SCore.cs
@@ -2050,7 +2050,7 @@ namespace StardewModdingAPI.Framework
                         IModRegistry modRegistryHelper = new ModRegistryHelper(mod, this.ModRegistry, proxyFactory, monitor);
                         IMultiplayerHelper multiplayerHelper = new MultiplayerHelper(mod, this.Multiplayer);
 
-                        modHelper = new ModHelper(mod, mod.DirectoryPath, () => this.GetCurrentGameInstance().Input, events, gameContentHelper, modContentHelper, contentPackHelper, commandHelper, dataHelper, modRegistryHelper, reflectionHelper, multiplayerHelper, translationHelper);
+                        modHelper = new ModHelper(mod, mod.DirectoryPath, () => this.GetCurrentGameInstance().Input, events, gameContentHelper, modContentHelper, contentPackHelper, commandHelper, dataHelper, modRegistryHelper, reflectionHelper, multiplayerHelper, translationHelper, this.Settings.GenerateConfigSchemas);
                     }
 
                     // init mod

--- a/src/SMAPI/IDataHelper.cs
+++ b/src/SMAPI/IDataHelper.cs
@@ -27,12 +27,11 @@ namespace StardewModdingAPI
         void WriteJsonFile<TModel>(string path, TModel? data)
             where TModel : class;
 
-        /// <summary>Save the schema of the data to a JSON file in the mod's folder.</summary>
+        /// <summary>Save a data model schema to a JSON file in the mod's folder.</summary>
         /// <typeparam name="TModel">The model type. This should be a plain class that has public properties for the data you want. The properties can be complex types.</typeparam>
         /// <param name="path">The file path relative to the mod folder.</param>
-        /// <param name="data">The arbitrary data to save.</param>
         /// <exception cref="InvalidOperationException">The <paramref name="path"/> is not relative or contains directory climbing (../).</exception>
-        void WriteJsonSchemaFile<TModel>(string path, TModel data)
+        void WriteJsonSchemaFile<TModel>(string path)
             where TModel : class;
 
         /****

--- a/src/SMAPI/IDataHelper.cs
+++ b/src/SMAPI/IDataHelper.cs
@@ -27,6 +27,14 @@ namespace StardewModdingAPI
         void WriteJsonFile<TModel>(string path, TModel? data)
             where TModel : class;
 
+        /// <summary>Save the schema of the data to a JSON file in the mod's folder.</summary>
+        /// <typeparam name="TModel">The model type. This should be a plain class that has public properties for the data you want. The properties can be complex types.</typeparam>
+        /// <param name="path">The file path relative to the mod folder.</param>
+        /// <param name="data">The arbitrary data to save.</param>
+        /// <exception cref="InvalidOperationException">The <paramref name="path"/> is not relative or contains directory climbing (../).</exception>
+        void WriteJsonSchemaFile<TModel>(string path, TModel data)
+            where TModel : class;
+
         /****
         ** Save file
         ****/

--- a/src/SMAPI/SMAPI.config.json
+++ b/src/SMAPI/SMAPI.config.json
@@ -172,5 +172,12 @@ in future SMAPI versions.
      * the mod author.
      */
     "ModsToLoadEarly": [],
-    "ModsToLoadLate": []
+    "ModsToLoadLate": [],
+
+    /**
+     * Whether to generate a `config.schema.json` file next to each mod's `config.json` file.
+     *
+     * This can be used by separate tools like mod managers to enable config editing features.
+    */
+    "GenerateConfigSchemas": false
 }


### PR DESCRIPTION
Resolves #928.

## Changes

- Adds a new dependency to `SMAPI.Toolkit`: `NJsonSchema` for schema generation.
- Adds `GenerateConfigSchema` option to `SConfig` that's set to `false` by default.
- Adds `IDataHelper.WriteJsonSchemaFile` and `JsonHelper.WriteJsonSchemaFile` to generate and write the schema to file.
- Updates `ModHelper.ReadConfig` to generate the file `config.schema.json`.

## Notes

I think `develop` references DLLs from Stardew Valley 1.6 that I don't have access with, so I had to create the code on `stable` and port it to `develop`.

I'm not sure how to test this PR, there aren't any unit tests that I can run. I thought about installing latest SMAPI normally and just overwriting the DLLs in the game folder with the ones I build using the PR. However, I don't even know if that works with the .NET DLL resolution process...