### PR TITLE
Add PREFER_TERMINAL_NAME option for Linux/macOS users

### DIFF
--- a/src/SMAPI.Installer/assets/unix-launcher.sh
+++ b/src/SMAPI.Installer/assets/unix-launcher.sh
@@ -13,6 +13,8 @@ SKIP_TERMINAL=false
 # Whether to avoid opening a separate terminal, but still send the usual log output to the console.
 USE_CURRENT_SHELL=false
 
+# Specify terminal name to open and output logs
+PREFER_TERMINAL_NAME=""
 
 ##########
 ## Read environment variables
@@ -23,6 +25,9 @@ fi
 if [ "$SMAPI_USE_CURRENT_SHELL" == "true" ]; then
     USE_CURRENT_SHELL=true
 fi
+if [ "$SMAPI_PREFER_TERMINAL_NAME" != "" ]; then
+    PREFER_TERMINAL_NAME=$SMAPI_PREFER_TERMINAL_NAME
+fi
 
 
 ##########
@@ -32,6 +37,9 @@ while [ "$#" -gt 0 ]; do
     case "$1" in
         --skip-terminal ) SKIP_TERMINAL=true; shift ;;
         --use-current-shell ) USE_CURRENT_SHELL=true; shift ;;
+        # ${1#*=}, It removes everything before the equals sign (including the equals sign) from $1
+        # leaving only what comes after the equals sign
+        --prefer-terminal-name=* ) PREFER_TERMINAL_NAME="${1#*=}"; shift ;;
         -- ) shift; break ;;
         * ) shift ;;
     esac
@@ -92,13 +100,18 @@ else
 
     # run in terminal
     if [ "$USE_CURRENT_SHELL" == "false" ]; then
-        # select terminal (prefer xterm for best compatibility, then known supported terminals)
-        for terminal in xterm gnome-terminal kitty terminator xfce4-terminal konsole terminal termite alacritty mate-terminal x-terminal-emulator wezterm; do
-            if command -v "$terminal" 2>/dev/null; then
-                export TERMINAL_NAME=$terminal
-                break;
-            fi
-        done
+        # if user said preferred terminal
+        if [ "$PREFER_TERMINAL_NAME" != "" ]; then
+            export TERMINAL_NAME=$PREFER_TERMINAL_NAME
+        else
+            # select terminal (prefer xterm for best compatibility, then known supported terminals)
+            for terminal in xterm gnome-terminal kitty terminator xfce4-terminal konsole terminal termite alacritty mate-terminal x-terminal-emulator wezterm; do
+                if command -v "$terminal" 2>/dev/null; then
+                    export TERMINAL_NAME=$terminal
+                    break;
+                fi
+            done
+        fi
 
         # find the true shell behind x-terminal-emulator
         if [ "$TERMINAL_NAME" = "x-terminal-emulator" ]; then


### PR DESCRIPTION
I just use SMAPI under linux today, but was unable to start the game with SMAPI, i resolved already by looking in GitHub issue.

> konsole is the terminal choices by launch script, but using it causes the game to not start. edit script file, move wezterm to first solved. (i use wezterm and konsole)

Even if the game were to launch correctly, I would still prefer to use ‘wezterm’ as possible. However, directly editing the start script file doesn’t seem like an elegant solution to the problem.

I've seen similar can't start issues in github issues, such as having to manually modify the script to change the order of probing terminals to get the game to start or to use a specific terminal.

Given the above, I propose the addition of a `PREFER_TERMINAL_NAME` option for users. This would allow users to specify their preferred terminal or fix launch terminal problem without having to manually edit the script.