### PR TITLE
Expose `DoesAssetExist<T>(IAssetName)` to Mods

### DIFF
--- a/src/SMAPI/Framework/ContentManagers/ModContentManager.cs
+++ b/src/SMAPI/Framework/ContentManagers/ModContentManager.cs
@@ -79,6 +79,7 @@ namespace StardewModdingAPI.Framework.ContentManagers
             if (base.DoesAssetExist<T>(assetName))
                 return true;
 
+            assetName = this.ResolveAssetName(assetName);
             FileInfo file = this.GetModFile<T>(assetName.Name);
             return file.Exists;
         }
@@ -94,17 +95,8 @@ namespace StardewModdingAPI.Framework.ContentManagers
             // for more background info.
             //
 
-            // resolve managed asset key
-            {
-                if (this.Coordinator.TryParseManagedAssetKey(assetName.Name, out string? contentManagerID, out IAssetName? relativePath))
-                {
-                    if (contentManagerID != this.Name)
-                        this.ThrowLoadError(assetName, ContentLoadErrorType.AccessDenied, "can't load a different mod's managed asset key through this mod content manager.");
-                    assetName = relativePath;
-                }
-            }
-
             // get local asset
+            assetName = this.ResolveAssetName(assetName);
             T asset;
             try
             {
@@ -159,6 +151,22 @@ namespace StardewModdingAPI.Framework.ContentManagers
         /*********
         ** Private methods
         *********/
+        /// <summary>Get the relative mod file path from an asset name.</summary>
+        /// <param name="assetName">The asset name to parse.</param>
+        /// <exception cref="SContentLoadException">The <paramref name="assetName"/> matches a different mod's content manager.</exception>
+        private IAssetName ResolveAssetName(IAssetName assetName)
+        {
+            if (this.Coordinator.TryParseManagedAssetKey(assetName.Name, out string? contentManagerId, out IAssetName? relativePath))
+            {
+                if (contentManagerId != this.Name)
+                    this.ThrowLoadError(assetName, ContentLoadErrorType.AccessDenied, "can't load a different mod's managed asset key through this mod content manager.");
+
+                assetName = relativePath;
+            }
+
+            return assetName;
+        }
+
         /// <summary>Load an unpacked font file (<c>.fnt</c>).</summary>
         /// <typeparam name="T">The type of asset to load.</typeparam>
         /// <param name="assetName">The asset name relative to the loader root directory.</param>

--- a/src/SMAPI/Framework/ModHelpers/GameContentHelper.cs
+++ b/src/SMAPI/Framework/ModHelpers/GameContentHelper.cs
@@ -68,6 +68,13 @@ namespace StardewModdingAPI.Framework.ModHelpers
         }
 
         /// <inheritdoc />
+        public bool DoesAssetExist<T>(IAssetName assetName)
+            where T : notnull
+        {
+            return this.GameContentManager.DoesAssetExist<T>(assetName);
+        }
+
+        /// <inheritdoc />
         public T Load<T>(string key)
             where T : notnull
         {

--- a/src/SMAPI/Framework/ModHelpers/ModContentHelper.cs
+++ b/src/SMAPI/Framework/ModHelpers/ModContentHelper.cs
@@ -47,6 +47,13 @@ namespace StardewModdingAPI.Framework.ModHelpers
         }
 
         /// <inheritdoc />
+        public bool DoesAssetExist<T>(IAssetName assetName)
+            where T : notnull
+        {
+            return this.ModContentManager.DoesAssetExist<T>(assetName);
+        }
+
+        /// <inheritdoc />
         public T Load<T>(string relativePath)
             where T : notnull
         {

--- a/src/SMAPI/Framework/ModHelpers/ModContentHelper.cs
+++ b/src/SMAPI/Framework/ModHelpers/ModContentHelper.cs
@@ -47,10 +47,10 @@ namespace StardewModdingAPI.Framework.ModHelpers
         }
 
         /// <inheritdoc />
-        public bool DoesAssetExist<T>(IAssetName assetName)
+        public bool DoesAssetExist<T>(string relativePath)
             where T : notnull
         {
-            return this.ModContentManager.DoesAssetExist<T>(assetName);
+            return this.ModContentManager.DoesAssetExist<T>(this.GetInternalAssetName(relativePath));
         }
 
         /// <inheritdoc />

--- a/src/SMAPI/IGameContentHelper.cs
+++ b/src/SMAPI/IGameContentHelper.cs
@@ -28,6 +28,12 @@ namespace StardewModdingAPI
         /// <exception cref="ArgumentException">The <paramref name="rawName"/> is null or empty.</exception>
         IAssetName ParseAssetName(string rawName);
 
+        /// <summary>Get whether an asset exists and can be loaded.</summary>
+        /// <typeparam name="T">The expected asset type.</typeparam>
+        /// <param name="assetName">The normalized asset name.</param>
+        bool DoesAssetExist<T>(IAssetName assetName)
+            where T : notnull;
+
         /// <summary>Load content from the game folder or mod folder (if not already cached), and return it. When loading a <c>.png</c> file, this must be called outside the game's draw loop.</summary>
         /// <typeparam name="T">The expected data type. The main supported types are <see cref="Map"/>, <see cref="Texture2D"/>, dictionaries, and lists; other types may be supported by the game's content pipeline.</typeparam>
         /// <param name="assetName">The asset name to load.</param>

--- a/src/SMAPI/IModContentHelper.cs
+++ b/src/SMAPI/IModContentHelper.cs
@@ -11,10 +11,12 @@ namespace StardewModdingAPI
         /*********
         ** Public methods
         *********/
-        /// <summary>Get whether an asset exists and can be loaded.</summary>
+        /// <summary>Get whether a file within the mod folder exists.</summary>
         /// <typeparam name="T">The expected asset type.</typeparam>
-        /// <param name="assetName">The normalized asset name.</param>
-        bool DoesAssetExist<T>(IAssetName assetName)
+        /// <param name="relativePath">The local path to a content file relative to the mod folder.</param>
+        /// <exception cref="ArgumentException">The <paramref name="relativePath"/> is empty or contains invalid characters.</exception>
+        /// <exception cref="ContentLoadException">The content asset couldn't be loaded (e.g. because it doesn't exist).</exception>
+        bool DoesAssetExist<T>(string relativePath)
             where T : notnull;
 
         /// <summary>Load content from the mod folder and return it. When loading a <c>.png</c> file, this must be called outside the game's draw loop.</summary>

--- a/src/SMAPI/IModContentHelper.cs
+++ b/src/SMAPI/IModContentHelper.cs
@@ -11,6 +11,12 @@ namespace StardewModdingAPI
         /*********
         ** Public methods
         *********/
+        /// <summary>Get whether an asset exists and can be loaded.</summary>
+        /// <typeparam name="T">The expected asset type.</typeparam>
+        /// <param name="assetName">The normalized asset name.</param>
+        bool DoesAssetExist<T>(IAssetName assetName)
+            where T : notnull;
+
         /// <summary>Load content from the mod folder and return it. When loading a <c>.png</c> file, this must be called outside the game's draw loop.</summary>
         /// <typeparam name="T">The expected data type. The main supported types are <see cref="Map"/>, <see cref="Texture2D"/>, <see cref="IRawTextureData"/>, and data structures; other types may be supported by the game's content pipeline.</typeparam>
         /// <param name="relativePath">The local path to a content file relative to the mod folder.</param>


### PR DESCRIPTION
This adds `DoesAssetExist<T>(IAssetName)` to `IGameContentHelper` and `IModContentHelper`.

The method exists on the wrapped `IContentManager` instances, so we just need to pass it along. Super simple work.