### PR TITLE
Adding gamemoderun to unix launch script

### DIFF
--- a/src/SMAPI.Installer/assets/unix-launcher.sh
+++ b/src/SMAPI.Installer/assets/unix-launcher.sh
@@ -92,9 +92,16 @@ if [ "$(uname)" == "Darwin" ]; then
 
 # Linux
 else
-    # choose binary file to launch
-    LAUNCH_FILE="./StardewModdingAPI"
-    export LAUNCH_FILE
+    # check if gamemoderun exists, if that is not the case start SMAPI normally
+    if command -v gamemoderun &> /dev/null
+    then
+        # Run SMAPI with using gamemoderun, which automatically boosts the system for the game
+        LAUNCH_FILE="gamemoderun ./StardewModdingAPI"
+        export LAUNCH_FILE
+    else
+        LAUNCH_FILE="./StardewModdingAPI"
+        export LAUNCH_FILE
+    fi
 
     # run in terminal
     if [ "$USE_CURRENT_SHELL" == "false" ]; then


### PR DESCRIPTION
This is the first part of adding gamemode support (#950).
This PR adds gamemoderun to the unix launch script.
I used the modified script on my laptop (AMD Ryzen 7 3700U, Kubuntu 23.10) for at least 30 hours of gameplay and never encountered any issues.
There is already a fallback in case gamemode is not installed on the system.
It should work just fine, but i only tested it by negating the if operation not on a system without gamemode.

The second part would be adding a default config file, which is not part of this PR.