### PR TITLE
Log mod assembly versions when loading mods

### DIFF
--- a/src/SMAPI/Framework/SCore.cs
+++ b/src/SMAPI/Framework/SCore.cs
@@ -1912,7 +1912,14 @@ namespace StardewModdingAPI.Framework
                     this.Monitor.Log($"   {mod.DisplayName} (from {relativePath}, ID: {mod.Manifest.UniqueID}) [content pack]...");
                 // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract -- mod may be invalid at this point
                 else if (mod.Manifest?.EntryDll != null)
-                    this.Monitor.Log($"   {mod.DisplayName} (from {relativePath}{Path.DirectorySeparatorChar}{mod.Manifest.EntryDll}, ID: {mod.Manifest.UniqueID})..."); // don't use Path.Combine here, since EntryDLL might not be valid
+                {
+                    FileInfo assemblyFile = this.GetFileLookup(mod.DirectoryPath).GetFile(mod.Manifest.EntryDll!);
+                    var assemblyVersion = System.Diagnostics.FileVersionInfo.GetVersionInfo(assemblyFile.FullName);
+                    string assemblyVersionString = "null";
+                    if (assemblyVersion != null)
+                        assemblyVersionString = assemblyVersion.FilePrivatePart == 0 ? $"{assemblyVersion.FileMajorPart}.{assemblyVersion.FileMinorPart}.{assemblyVersion.FileBuildPart}" : (assemblyVersion.FileVersion ?? "null");
+                    this.Monitor.Log($"   {mod.DisplayName} (from {relativePath}{Path.DirectorySeparatorChar}{mod.Manifest.EntryDll}, ID: {mod.Manifest.UniqueID}, assembly version: {assemblyVersionString})..."); // don't use Path.Combine here, since EntryDLL might not be valid
+                }
                 else
                     this.Monitor.Log($"   {mod.DisplayName} (from {relativePath}, ID: {mod.Manifest?.UniqueID ?? "<unknown>"})...");
             }


### PR DESCRIPTION
Useful for seeing if a user updated the manifest version but didn't actually update the mod.

Example from log (though I took out lines like failing to load PDBs, loading extra assemblies, etc.):

```
[13:06:43 DEBUG SMAPI] Loading mods...
[13:06:43 TRACE SMAPI]    Console Code (from Mods\ConsoleCode\ConsoleCode.dll, ID: spacechase0.ConsoleCode, assembly version: 1.1.0)...
[13:06:45 TRACE SMAPI]    Console Commands (from Mods\ConsoleCommands\ConsoleCommands.dll, ID: SMAPI.ConsoleCommands, assembly version: 4.0.8)...
[13:06:45 TRACE SMAPI]    Content Patcher (from Mods\ContentPatcher\ContentPatcher.dll, ID: Pathoschild.ContentPatcher, assembly version: 2.4.0)...
[13:06:45 TRACE SMAPI]    Experience Bars (from Mods\ExperienceBars\ExperienceBars.dll, ID: spacechase0.ExperienceBars, assembly version: 1.4.5)...
[13:06:45 TRACE SMAPI]    Fast Animations (from Mods\FastAnimations\FastAnimations.dll, ID: Pathoschild.FastAnimations, assembly version: 1.11.8)...
[13:06:45 TRACE SMAPI]    Generic Mod Config Menu (from Mods\GenericModConfigMenu\GenericModConfigMenu.dll, ID: spacechase0.GenericModConfigMenu, assembly version: 1.12.0)...
[13:06:45 TRACE SMAPI]    Gradient Hair Colors (from Mods\GradientHairColors\GradientHairColors.dll, ID: spacechase0.GradientHairColors, assembly version: 1.1.1)...
[13:06:45 TRACE SMAPI]    Hybrid Crop Engine (from Mods\HybridCropEngine\HybridCropEngine.dll, ID: spacechase0.HybridCropEngine, assembly version: 1.1.5)...
[13:06:45 TRACE SMAPI]    SpaceCore (from Mods\SpaceCore\SpaceCore.dll, ID: spacechase0.SpaceCore, assembly version: 1.24.2)...
```