### PR TITLE
fix display device issues.

### DIFF
--- a/src/SMAPI/Framework/Rendering/SDisplayDevice.cs
+++ b/src/SMAPI/Framework/Rendering/SDisplayDevice.cs
@@ -2,6 +2,8 @@ using System;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
+
+using xTile;
 using xTile.Dimensions;
 using xTile.Layers;
 using xTile.ObjectModel;
@@ -12,6 +14,11 @@ namespace StardewModdingAPI.Framework.Rendering
     /// <summary>A map display device which overrides the draw logic to support tile rotation.</summary>
     internal class SDisplayDevice : SXnaDisplayDevice
     {
+        /// <summary>
+        /// Gets a value indicating whether the display device's cache needs to be refreshed.
+        /// </summary>
+        internal bool IsDirty { get; private set; } = false;
+
         /*********
         ** Public methods
         *********/
@@ -31,9 +38,16 @@ namespace StardewModdingAPI.Framework.Rendering
             if (tile == null)
                 return;
             xTile.Dimensions.Rectangle tileImageBounds = tile.TileSheet.GetTileImageBounds(tile.TileIndex);
-            Texture2D tileSheetTexture = this.m_tileSheetTextures[tile.TileSheet];
+
+            if (!this.m_tileSheetTextures.TryGetValue(tile.TileSheet, out var tileSheetTexture))
+            {
+                this.IsDirty = true;
+                return;
+            }
+
             if (tileSheetTexture.IsDisposed)
                 return;
+
             this.m_tilePosition.X = location.X;
             this.m_tilePosition.Y = location.Y;
             this.m_sourceRectangle.X = tileImageBounds.X;
@@ -50,6 +64,16 @@ namespace StardewModdingAPI.Framework.Rendering
 
             // apply
             this.m_spriteBatchAlpha.Draw(tileSheetTexture, this.m_tilePosition, this.m_sourceRectangle, this.m_modulationColour, rotation, origin, Layer.zoom, effects, layerDepth);
+        }
+
+        /// <summary>
+        /// Populates a map's tilesheets into the cache.
+        /// </summary>
+        /// <param name="map">Map to populate.</param>
+        internal void PopulateTilesheets(Map? map)
+        {
+            map?.LoadTileSheets(this);
+            this.IsDirty = false;
         }
 
         /// <summary>Get the sprite effects to apply for a tile.</summary>

--- a/src/SMAPI/Framework/Rendering/SXnaDisplayDevice.cs
+++ b/src/SMAPI/Framework/Rendering/SXnaDisplayDevice.cs
@@ -1,19 +1,28 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
+
 using xTile.Dimensions;
 using xTile.Display;
 using xTile.Layers;
 using xTile.Tiles;
+
 using Rectangle = xTile.Dimensions.Rectangle;
+
+// Remarks:
+// The vanilla game uses a dictionary to cache a tilesheet -> Texture2d lookup.
+// but SMAPI cannot reasonably keep track of lifetimes for tilesheets.
+// In particular, mods may add or remove tilesheets at any time.
 
 namespace StardewModdingAPI.Framework.Rendering
 {
     /// <summary>A map display device which reimplements the default logic.</summary>
-    /// <remarks>This is an exact copy of <see cref="XnaDisplayDevice"/>, except that private fields are protected and all methods are virtual.</remarks>
+    /// <remarks>This is an exact copy of <see cref="XnaDisplayDevice"/>, except that private fields are protected and all methods are virtual
+    /// and the tilesheet cache has been replaced with a conditional weak table</remarks>
     [SuppressMessage("ReSharper", "InconsistentNaming", Justification = $"Field naming deliberately matches {nameof(XnaDisplayDevice)} to minimize differences.")]
     internal class SXnaDisplayDevice : IDisplayDevice
     {
@@ -24,7 +33,7 @@ namespace StardewModdingAPI.Framework.Rendering
         protected readonly GraphicsDevice m_graphicsDevice;
         protected SpriteBatch m_spriteBatchAlpha;
         protected SpriteBatch m_spriteBatchAdditive;
-        protected readonly Dictionary<TileSheet, Texture2D> m_tileSheetTextures;
+        protected readonly ConditionalWeakTable<TileSheet, Texture2D> m_tileSheetTextures;
         protected Vector2 m_tilePosition;
         protected Microsoft.Xna.Framework.Rectangle m_sourceRectangle;
         protected readonly Color m_modulationColour;
@@ -42,7 +51,7 @@ namespace StardewModdingAPI.Framework.Rendering
             this.m_graphicsDevice = graphicsDevice;
             this.m_spriteBatchAlpha = new SpriteBatch(graphicsDevice);
             this.m_spriteBatchAdditive = new SpriteBatch(graphicsDevice);
-            this.m_tileSheetTextures = new Dictionary<TileSheet, Texture2D>();
+            this.m_tileSheetTextures = new();
             this.m_tilePosition = new Vector2();
             this.m_sourceRectangle = new Microsoft.Xna.Framework.Rectangle();
             this.m_modulationColour = Color.White;
@@ -53,7 +62,8 @@ namespace StardewModdingAPI.Framework.Rendering
         public virtual void LoadTileSheet(TileSheet tileSheet)
         {
             Texture2D texture2D = this.m_contentManager.Load<Texture2D>(tileSheet.ImageSource);
-            this.m_tileSheetTextures[tileSheet] = texture2D;
+            if (!texture2D.IsDisposed)
+                this.m_tileSheetTextures.AddOrUpdate(tileSheet, texture2D); // change here.
         }
 
         /// <summary>Unload a tilesheet texture.</summary>
@@ -94,8 +104,9 @@ namespace StardewModdingAPI.Framework.Rendering
             if (tile == null)
                 return;
             Rectangle tileImageBounds = tile.TileSheet.GetTileImageBounds(tile.TileIndex);
-            Texture2D tileSheetTexture = this.m_tileSheetTextures[tile.TileSheet];
-            if (tileSheetTexture.IsDisposed)
+
+            // change here. 
+            if (!this.m_tileSheetTextures.TryGetValue(tile.TileSheet, out var tileSheetTexture) || tileSheetTexture.IsDisposed)
                 return;
             this.m_tilePosition.X = location.X;
             this.m_tilePosition.Y = location.Y;

--- a/src/SMAPI/Framework/SGame.cs
+++ b/src/SMAPI/Framework/SGame.cs
@@ -7,6 +7,7 @@ using StardewModdingAPI.Enums;
 using StardewModdingAPI.Events;
 using StardewModdingAPI.Framework.Input;
 using StardewModdingAPI.Framework.Reflection;
+using StardewModdingAPI.Framework.Rendering;
 using StardewModdingAPI.Framework.StateTracking.Snapshots;
 using StardewModdingAPI.Framework.Utilities;
 using StardewModdingAPI.Internal;
@@ -201,6 +202,13 @@ namespace StardewModdingAPI.Framework
             {
                 this.Input.TrueUpdate();
                 this.Watchers = new WatcherCore(this.Input, (ObservableCollection<GameLocation>)this._locations);
+            }
+
+            // crosscheck rendering device.
+            if (Game1.mapDisplayDevice is SDisplayDevice sDisplayDevice
+                && sDisplayDevice.IsDirty == true && Game1.currentLocation is { } loc)
+            {
+                sDisplayDevice.PopulateTilesheets(loc.Map);
             }
 
             // update


### PR DESCRIPTION
Hi Pathos!

This pull request aims to fix two issues.

1. Map edits in splitscreen sometimes cause crashes. See [this log](https://smapi.io/log/e0b0d2bdc12742508d6a813f8e8a8683?Levels=trace%7Edebug%7Einfo%7Ewarn%7Eerror%7Ealert%7Ecritical&Page=14&PerPage=1000), or [this log](https://smapi.io/log/ded0e4324d07493381f577b942ba5706?Levels=trace%7Edebug%7Einfo%7Ewarn%7Eerror%7Ealert%7Ecritical&Page=6&PerPage=1000).
2. Map edits cause SDisplayDevice to leak memory.

Effectively, SDisplayDevice has a cache of `TileSheet` to `Texture2D`. This cache is supposed to be populated in a number of spots, primarily `GameLocation.loadMap`, which SMAPI calls when it propogates map edits. However, in splitscreen, the game maintains multiple separate instances of `Game1.mapDisplayDevice` and only the active player's mapDisplayDevice gets updated.

Additionally, when SMAPI loads a map for editing, it loads the map cleanly from disk, so the `TileSheet` references are all new. This means that while the cache would not consider the two instances to be the same. However, the map instance itself is shared between all players in splitscreen (it comes from the same content cache.) Because of this, when the other player tries to draw the map, the map's (new) tilesheet instances do not match up with the mapDisplayDevice's old tilesheet instances. This causes a crash.

This is not a common crash since the game will call Map.LoadTilesheets sometimes. Most usefully, it'll do so every time the player warps, so this should only happen if the two players are on the same map.

Finally, since these are new `TileSheet` instances and SMAPI never clears the old ones, over time this cache will tend to leak memory.

To solve this I:

1. Replaced the cache with a ConditionalWeakTable. I went with this route because SMAPI can't really control if some mod decides to add their own tilesheet at any point (Aquarium used to do this, for example.). 
2. A missing value is no longer a hard crash, just a tilesheet that isn't drawn temporarily.
3. Before each update tick, the game will check to see if a tilesheet reference was not found in the last draw cycle, and re-load the map tilesheets if so.

I considered:
1. Updating the other players' mapDisplayDevice, but there's no good way to get to that.
2. Keeping the cache a Dictionary instead of a ConditionalWeakTable and accepting the memory leak.

