### PR TITLE
Fix for crashes in split-screen mode after evend ends

### DIFF
--- a/src/SMAPI/Framework/Rendering/SDisplayDevice.cs
+++ b/src/SMAPI/Framework/Rendering/SDisplayDevice.cs
@@ -30,6 +30,10 @@ namespace StardewModdingAPI.Framework.Rendering
             // identical to XnaDisplayDevice
             if (tile == null)
                 return;
+
+            if (!this.m_tileSheetTextures.TryGetValue(tile.TileSheet, out Texture2D tileSheetTexture) || tileSheetTexture.IsDisposed)
+                return;
+                
             xTile.Dimensions.Rectangle tileImageBounds = tile.TileSheet.GetTileImageBounds(tile.TileIndex);
             Texture2D tileSheetTexture = this.m_tileSheetTextures[tile.TileSheet];
             if (tileSheetTexture.IsDisposed)

--- a/src/SMAPI/Framework/Rendering/SDisplayDevice.cs
+++ b/src/SMAPI/Framework/Rendering/SDisplayDevice.cs
@@ -31,7 +31,7 @@ namespace StardewModdingAPI.Framework.Rendering
             if (tile == null)
                 return;
 
-            if (!this.m_tileSheetTextures.TryGetValue(tile.TileSheet, out Texture2D tileSheetTexture) || tileSheetTexture.IsDisposed)
+            if (!this.m_tileSheetTextures.TryGetValue(tile.TileSheet, out Texture2D tileSheetTextureLookup) || tileSheetTextureLookup.IsDisposed)
                 return;
                 
             xTile.Dimensions.Rectangle tileImageBounds = tile.TileSheet.GetTileImageBounds(tile.TileIndex);


### PR DESCRIPTION
This is a workaround for the issue described in #966 

I added a check to see if a given key is present in the tileSheet dictionary before trying to get its value. If the key is not present, return null instead. This avoids a `KeyNotFoundException`and crashing the game.

However, this causes the left player's farm to display a blank background when sent home from an event, but since the game places you in front of your house at night anyway it is better than a full on crash to desktop. I am using this modified version for my couch-coop playthrough now and wanted to share it.