### PR TITLE
Fix broken redirection syntax when checking for terminals

### DIFF
--- a/src/SMAPI.Installer/assets/install on Linux.sh
+++ b/src/SMAPI.Installer/assets/install on Linux.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
 function open_in_terminal { # Checks for a few different terminal emulators to launch the installer through
-    if which konsole 2&>1 >/dev/null; then # KDE Konsole
+    if which konsole 2>&1 >/dev/null; then # KDE Konsole
         konsole -e $1
-    elif which alacritty 2&>1 >/dev/null; then # Alacritty
+    elif which alacritty 2>&1 >/dev/null; then # Alacritty
         alacritty -e $1
-    elif which gnome-terminal 2&>1 >/dev/null; then # GNOME Terminal
+    elif which gnome-terminal 2>&1 >/dev/null; then # GNOME Terminal
         gnome-terminal -- $1
-    elif which xterm 2&>1 >/dev/null; then # Xterm
+    elif which xterm 2>&1 >/dev/null; then # Xterm
         xterm -e $1
     else # Use notify-send to send a message that none of these terminals were found installed and instruct the user to manually invoke this script through a terminal
         notify-send --app-name="SMAPI Installer" --urgency=critical "Failed to find a terminal to open installer with. Please use a terminal program to open the 'install on Linux.sh' script"


### PR DESCRIPTION
In my original PR ( #937 ) to add terminal checking to `Install on Linux.sh`, I messed up the output redirection syntax, resulting in the script never finding a terminal to open the script with. Not even sure if I tested the original patch at this point, but this does allow the script to find a terminal.