### PR TITLE
Cache ModContentManagers loading of images

### DIFF
--- a/src/SMAPI/Framework/ContentManagers/ModContentManager.cs
+++ b/src/SMAPI/Framework/ContentManagers/ModContentManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Buffers;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -44,6 +45,8 @@ internal sealed class ModContentManager : BaseContentManager
 
     /// <summary>If a map tilesheet's image source has no file extensions, the file extensions to check for in the local mod folder.</summary>
     private static readonly string[] LocalTilesheetExtensions = [".png", ".xnb"];
+
+    private readonly Dictionary<string, RawTextureData> TextureCache = [];
 
 
     /*********
@@ -220,6 +223,12 @@ internal sealed class ModContentManager : BaseContentManager
     [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "The 'forRawData' parameter is only added for mods which may intercept this method.")]
     private IRawTextureData LoadRawImageData(FileInfo file, bool forRawData)
     {
+        if (this.TextureCache.TryGetValue(file.FullName, out var cacheResult))
+        {
+            var cacheColors = cacheResult.Data;
+            return new RawTextureData(cacheResult.Width, cacheResult.Height, cacheColors);
+        }
+
         // load raw data
         int width;
         int height;
@@ -238,13 +247,19 @@ internal sealed class ModContentManager : BaseContentManager
 
         // convert to XNA pixel format
         var pixels = GC.AllocateUninitializedArray<Color>(rawPixels.Length);
+        var pixelCache = GC.AllocateUninitializedArray<Color>(rawPixels.Length);
         for (int i = 0; i < pixels.Length; i++)
         {
             SKPMColor pixel = rawPixels[i];
             pixels[i] = pixel.Alpha == 0
                 ? Color.Transparent
                 : new Color(r: pixel.Red, g: pixel.Green, b: pixel.Blue, alpha: pixel.Alpha);
+
+            pixelCache[i] = pixel.Alpha == 0
+                ? Color.Transparent
+                : new Color(r: pixel.Red, g: pixel.Green, b: pixel.Blue, alpha: pixel.Alpha);
         }
+        this.TextureCache.Add(file.FullName, new RawTextureData(width, height, pixelCache));
 
         return new RawTextureData(width, height, pixels);
     }

--- a/src/SMAPI/Framework/ContentManagers/ModContentManager.cs
+++ b/src/SMAPI/Framework/ContentManagers/ModContentManager.cs
@@ -219,13 +219,15 @@ internal sealed class ModContentManager : BaseContentManager
     /// <param name="file">The file whose data to load.</param>
     /// <param name="forRawData">Whether the data is being loaded for an <see cref="IRawTextureData"/> (true) or <see cref="Texture2D"/> (false) instance.</param>
     /// <remarks>This is separate to let framework mods intercept the data before it's loaded, if needed.</remarks>
-    [SuppressMessage("ReSharper", "UnusedParameter.Local", Justification = "The 'forRawData' parameter is only added for mods which may intercept this method.")]
-    [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "The 'forRawData' parameter is only added for mods which may intercept this method.")]
     private IRawTextureData LoadRawImageData(FileInfo file, bool forRawData)
     {
         if (this.TextureCache.TryGetValue(file.FullName, out var cacheResult))
         {
             var cacheColors = cacheResult.Data;
+            if (forRawData)
+            {
+                return new RawTextureData(cacheResult.Width, cacheResult.Height, (Color[])cacheColors.Clone());
+            }
             return new RawTextureData(cacheResult.Width, cacheResult.Height, cacheColors);
         }
 
@@ -247,7 +249,9 @@ internal sealed class ModContentManager : BaseContentManager
 
         // convert to XNA pixel format
         var pixels = GC.AllocateUninitializedArray<Color>(rawPixels.Length);
-        var pixelCache = GC.AllocateUninitializedArray<Color>(rawPixels.Length);
+        Color[]? pixelCache = null;
+        if (forRawData)
+            pixelCache = GC.AllocateUninitializedArray<Color>(rawPixels.Length);
         for (int i = 0; i < pixels.Length; i++)
         {
             SKPMColor pixel = rawPixels[i];
@@ -255,11 +259,17 @@ internal sealed class ModContentManager : BaseContentManager
                 ? Color.Transparent
                 : new Color(r: pixel.Red, g: pixel.Green, b: pixel.Blue, alpha: pixel.Alpha);
 
-            pixelCache[i] = pixel.Alpha == 0
-                ? Color.Transparent
-                : new Color(r: pixel.Red, g: pixel.Green, b: pixel.Blue, alpha: pixel.Alpha);
+            if (pixelCache != null)
+            {
+                pixelCache[i] = pixel.Alpha == 0
+                    ? Color.Transparent
+                    : new Color(r: pixel.Red, g: pixel.Green, b: pixel.Blue, alpha: pixel.Alpha);
+            }
         }
-        this.TextureCache.Add(file.FullName, new RawTextureData(width, height, pixelCache));
+        if (pixelCache != null)
+            this.TextureCache.Add(file.FullName, new RawTextureData(width, height, pixelCache));
+        else
+            this.TextureCache.Add(file.FullName, new RawTextureData(width, height, pixels));
 
         return new RawTextureData(width, height, pixels);
     }


### PR DESCRIPTION
TODO: Add an off switch for content pack authors or have mods like Content Patcher invoke a method to clear the cache

Before:
https://smapi.io/log/d9c4b827f28242928f2a8aff9512a5ee
![image](https://github.com/user-attachments/assets/275c2558-5bb8-402b-b896-462c05478502)
https://smapi.io/json/none/1852f5afb3d9464a86e44ffa62e29287

After:
https://smapi.io/log/83897c04742e471a872a39b487bc1273
![image](https://github.com/user-attachments/assets/88967d18-c302-4767-9586-a7c6494b7003)
https://smapi.io/json/none/3b30032ffeed425cb02fd878308d51e1