### PR TITLE
Optimize map edits by skipping expensive tile index property copies

### DIFF
--- a/src/SMAPI/Framework/Content/AssetDataForMap.cs
+++ b/src/SMAPI/Framework/Content/AssetDataForMap.cs
@@ -8,6 +8,7 @@ using StardewValley;
 using xTile;
 using xTile.Dimensions;
 using xTile.Layers;
+using xTile.ObjectModel;
 using xTile.Tiles;
 using Rectangle = Microsoft.Xna.Framework.Rectangle;
 
@@ -90,8 +91,7 @@ internal class AssetDataForMap : AssetData<Map>, IAssetDataForMap
 
                 // add tilesheet
                 targetSheet = new TileSheet(id, target, sourceSheet.ImageSource, sourceSheet.SheetSize, sourceSheet.TileSize);
-                for (int i = 0, tileCount = sourceSheet.TileCount; i < tileCount; ++i)
-                    targetSheet.TileIndexProperties[i].CopyFrom(sourceSheet.TileIndexProperties[i]);
+                this.Reflection.GetField<PropertyCollection>(targetSheet, "m_propertyCollection").SetValue((PropertyCollection)sourceSheet.Properties);
                 target.AddTileSheet(targetSheet);
             }
 

--- a/src/SMAPI/Framework/Content/AssetDataForMap.cs
+++ b/src/SMAPI/Framework/Content/AssetDataForMap.cs
@@ -8,7 +8,6 @@ using StardewValley;
 using xTile;
 using xTile.Dimensions;
 using xTile.Layers;
-using xTile.ObjectModel;
 using xTile.Tiles;
 using Rectangle = Microsoft.Xna.Framework.Rectangle;
 
@@ -91,7 +90,7 @@ internal class AssetDataForMap : AssetData<Map>, IAssetDataForMap
 
                 // add tilesheet
                 targetSheet = new TileSheet(id, target, sourceSheet.ImageSource, sourceSheet.SheetSize, sourceSheet.TileSize);
-                this.Reflection.GetField<PropertyCollection>(targetSheet, "m_propertyCollection").SetValue((PropertyCollection)sourceSheet.Properties);
+                targetSheet.Properties.CopyFrom(sourceSheet.Properties);
                 target.AddTileSheet(targetSheet);
             }
 


### PR DESCRIPTION
TODO: do some extra checks to ensure that this optimization doesn't have negative side effects with the proposed optimization in Content Patcher.

Notes: The before/after include extra instrumentation that did not change between the builds.
"tileSheets" tracked L72 to L96
"sourceToTarget" tracked L101 to L111
"tileEdits" tracked L112 to the end.
there was an independent timer for the entire method contents and the logging only occured if that outer timer took >5ms

Before:
https://smapi.io/log/0e18a2cf478d4e0a9f1d66b2eaff697e?Mods=SMAPI&Levels=trace%7Ecritical&Filter=MapProfiling
![image](https://github.com/user-attachments/assets/9260eb0c-ea8c-43d2-a404-dbebc0475dc4)
https://smapi.io/json/none/d8d91c7f9abd4ed281f1aaa6bff8e1bd

After:
https://smapi.io/log/b4382cce0d734661aa576080082920a9?Mods=SMAPI&Levels=trace%7Ecritical&Filter=MapProfiling
![image](https://github.com/user-attachments/assets/8d2da0db-3ff0-490e-b422-4329a51a23e1)
https://smapi.io/json/none/3b37058c818d4cd4b8797cbb94820031
