### PR TITLE
Add CurseForge as valid updatekey to manifest schema

### DIFF
--- a/src/SMAPI.Web/wwwroot/schemas/manifest.json
+++ b/src/SMAPI.Web/wwwroot/schemas/manifest.json
@@ -108,7 +108,7 @@
             "type": "array",
             "items": {
                 "type": "string",
-                "pattern": "^(?i)(Chucklefish:\\d+|Nexus:\\d+|GitHub:[A-Za-z0-9_\\-\\.]+/[A-Za-z0-9_\\-]+|ModDrop:\\d+)(?: *@ *[a-zA-Z0-9_]+ *)?$",
+                "pattern": "^(?i)(Chucklefish:\\d+|Nexus:\\d+|GitHub:[A-Za-z0-9_\\-\\.]+/[A-Za-z0-9_\\-]+|ModDrop:\\d+|CurseForge:\\d+)(?: *@ *[a-zA-Z0-9_]+ *)?$",
                 "@errorMessages": {
                     "pattern": "Invalid update key; see https://stardewvalleywiki.com/Modding:Modder_Guide/APIs/Manifest#Update_checks for more info."
                 }


### PR DESCRIPTION
Currently, the [manifest schema](https://smapi.io/schemas/manifest.json) does not support CurseForge updatekeys. This PR adds validation for CurseForge update keys in the schema's regex.

The [wiki](https://stardewvalleywiki.com/Modding:Modder_Guide/APIs/Update_checks#Valid_sites) lists it as a valid updatekey, and I know it's used in update checks and on the SMAPI compatibility list site.

Given that it's a valid key to provide, it'd be nice if the schema supported it as well.