### PR TITLE
[Web] Add "number" as a valid type to LocalTokens definition

### DIFF
--- a/src/SMAPI.Web/wwwroot/schemas/content-patcher.json
+++ b/src/SMAPI.Web/wwwroot/schemas/content-patcher.json
@@ -634,7 +634,7 @@
                 }
             },
             "additionalProperties": {
-                "type": [ "boolean", "integer", "string" ]
+                "type": [ "boolean", "integer", "number", "string" ]
             }
         },
         "Position": {


### PR DESCRIPTION
LocalTokens support the number type, updating this to improve the validation of these instances