### PR TITLE
Allow limited directory climbing in mod tilesheet image sources

### DIFF
--- a/src/SMAPI/Framework/ContentManagers/ModContentManager.cs
+++ b/src/SMAPI/Framework/ContentManagers/ModContentManager.cs
@@ -413,8 +413,19 @@ internal sealed class ModContentManager : BaseContentManager
 
             // validate tilesheet path
             string errorPrefix = $"{this.ModName} loaded map '{relativeMapPath}' with invalid tilesheet path '{imageSource}'.";
-            if (Path.IsPathRooted(imageSource) || PathUtilities.GetSegments(imageSource).Contains(".."))
-                throw new SContentLoadException(ContentLoadErrorType.InvalidData, $"{errorPrefix} Tilesheet paths must be a relative path without directory climbing (../).");
+            if (Path.IsPathRooted(imageSource))
+                throw new SContentLoadException(ContentLoadErrorType.InvalidData, $"{errorPrefix} Tilesheet paths must not be an absolute path ({Path.GetPathRoot(imageSource)}).");
+
+            string[] imageSourcePathSegments = PathUtilities.GetSegments(imageSource);
+            if (imageSourcePathSegments.Contains(".."))
+            {
+                int climbingCount = imageSourcePathSegments.Count(segment => segment.Equals("..", StringComparison.OrdinalIgnoreCase));
+                if (climbingCount > 1)
+                {
+                    string[] offendingSegments = imageSourcePathSegments.TakeWhile(seg => seg.Equals("..")).ToArray();
+                    throw new SContentLoadException(ContentLoadErrorType.InvalidData, $"{errorPrefix} Tilesheet paths must not climb more than one directory ({string.Join('/', offendingSegments)}/).");
+                }
+            }
 
             // load best match
             try
@@ -467,8 +478,8 @@ internal sealed class ModContentManager : BaseContentManager
                 relativePath = Path.Combine(Path.GetDirectoryName(relativePath) ?? "", filename.TrimStart('.'));
         }
 
-        // get relative to map file
-        {
+        // get relative to map file unless path has directory climbing
+        if (!PathUtilities.GetSegments(relativePath).Contains("..")) {
             string localKey = Path.Combine(modRelativeMapFolder, relativePath);
             if (this.GetModFile<Texture2D>(localKey).Exists)
             {
@@ -524,8 +535,12 @@ internal sealed class ModContentManager : BaseContentManager
         string key = relativePath;
         string topFolder = PathUtilities.GetSegments(key, limit: 2)[0];
 
-        // convert image source relative to map file into asset key
-        if (!topFolder.Equals("Maps", StringComparison.OrdinalIgnoreCase))
+        // remove previously validated directory climbing if it exists
+        if (topFolder.Equals("..", StringComparison.OrdinalIgnoreCase))
+            key = key[2..];
+
+        // else convert image source relative to map file into asset key
+        else if (!topFolder.Equals("Maps", StringComparison.OrdinalIgnoreCase))
             key = Path.Combine("Maps", key);
 
         // remove file extension from unpacked file

--- a/src/SMAPI/Framework/ContentManagers/ModContentManager.cs
+++ b/src/SMAPI/Framework/ContentManagers/ModContentManager.cs
@@ -30,6 +30,9 @@ internal sealed class ModContentManager : BaseContentManager
     /*********
     ** Fields
     *********/
+    /// <summary>A path segment which navigates to the parent directory.</summary>
+    private const string DirectoryClimbingPathSegment = "..";
+
     /// <summary>Encapsulates SMAPI's JSON file parsing.</summary>
     private readonly JsonHelper JsonHelper;
 
@@ -420,7 +423,7 @@ internal sealed class ModContentManager : BaseContentManager
             //   2. Can only climb once (to avoid escaping the `Content` folder).
             //   3. Always relative to the `Content/Maps` folder (not the map file).
             {
-                const string climbSegment = "..";
+                const string climbSegment = ModContentManager.DirectoryClimbingPathSegment;
                 string[] pathSegments = PathUtilities.GetSegments(imageSource);
                 if (pathSegments.Contains(climbSegment))
                 {
@@ -481,7 +484,8 @@ internal sealed class ModContentManager : BaseContentManager
         }
 
         // get relative to map file unless path has directory climbing
-        if (!relativePath.StartsWith("..") && PathUtilities.GetSegments(relativePath, 2)[0] != "..") // directory climbing can only be at the start of the path
+        const string climbSegment = ModContentManager.DirectoryClimbingPathSegment;
+        if (!relativePath.StartsWith(climbSegment) && PathUtilities.GetSegments(relativePath, 2)[0] != climbSegment) // directory climbing can only be at the start of the path
         {
             string localKey = Path.Combine(modRelativeMapFolder, relativePath);
             if (this.GetModFile<Texture2D>(localKey).Exists)
@@ -536,15 +540,17 @@ internal sealed class ModContentManager : BaseContentManager
     private string GetContentKeyForTilesheetImageSource(string relativePath)
     {
         string key = relativePath;
-        string topFolder = PathUtilities.GetSegments(key, limit: 2)[0];
 
-        // remove previously validated directory climbing if it exists
-        if (topFolder.Equals("..", StringComparison.OrdinalIgnoreCase))
-            key = key[2..];
+        // make path relative to Content folder
+        {
+            string topFolder = PathUtilities.GetSegments(key, limit: 2)[0];
+            const string climbSegment = ModContentManager.DirectoryClimbingPathSegment;
 
-        // else convert image source relative to map file into asset key
-        else if (!topFolder.Equals("Maps", StringComparison.OrdinalIgnoreCase))
-            key = Path.Combine("Maps", key);
+            if (topFolder == climbSegment)
+                key = key[(climbSegment.Length + 1)..];
+            else if (!topFolder.Equals("Maps", StringComparison.OrdinalIgnoreCase))
+                key = Path.Combine("Maps", key);
+        }
 
         // remove file extension from unpacked file
         if (key.EndsWith(".png", StringComparison.OrdinalIgnoreCase))

--- a/src/SMAPI/Framework/ContentManagers/ModContentManager.cs
+++ b/src/SMAPI/Framework/ContentManagers/ModContentManager.cs
@@ -399,32 +399,33 @@ internal sealed class ModContentManager : BaseContentManager
         this.Monitor.VerboseLog($"Fixing tilesheet paths for map '{relativeMapPath}' from mod '{this.ModName}'...");
         foreach (TileSheet tilesheet in map.TileSheets)
         {
-            // get image source
+            // get image path
             tilesheet.ImageSource = this.NormalizePathSeparators(tilesheet.ImageSource);
             string imageSource = tilesheet.ImageSource;
+            if (fixEagerPathPrefixes && relativeMapFolder.Length > 0 && imageSource?.StartsWith(relativeMapFolder) is true)
+                imageSource = imageSource[(relativeMapFolder.Length + 1)..];
 
-            // validate image source
+            // ensure path isn't empty
             if (string.IsNullOrWhiteSpace(imageSource))
                 throw new SContentLoadException(ContentLoadErrorType.InvalidData, $"{this.ModName} loaded map '{relativeMapPath}' with invalid tilesheet '{tilesheet.Id}'. This tilesheet has no image source.");
 
-            // reverse incorrect eager tilesheet path prefixing
-            if (fixEagerPathPrefixes && relativeMapFolder.Length > 0 && imageSource.StartsWith(relativeMapFolder))
-                imageSource = imageSource[(relativeMapFolder.Length + 1)..];
-
-            // validate tilesheet path
+            // ensure path is relative
             if (Path.IsPathRooted(imageSource))
                 throw this.GetPathError(relativeMapFolder, imageSource, $"Tilesheet paths must not be an absolute path ({Path.GetPathRoot(imageSource)}).");
 
+            // ensure any directory climbing is valid
+            // Tilesheet paths are relative to either the `Content/Maps` folder or the map file. Directory climbing is
+            // restricted for safety and simplicity:
+            //   1. Can only climb at the start of the path (e.g. `../LooseSprites/Cursors` but not `Mines/../Barn`).
+            //   2. Can only climb once (to avoid escaping the `Content` folder).
+            //   3. Always relative to the `Content/Maps` folder (not the map file).
             {
-                string[] imageSourcePathSegments = PathUtilities.GetSegments(imageSource);
-                if (imageSourcePathSegments.Contains(".."))
+                const string climbSegment = "..";
+                string[] pathSegments = PathUtilities.GetSegments(imageSource);
+                if (pathSegments.Contains(climbSegment))
                 {
-                    int climbingCount = imageSourcePathSegments.Count(segment => segment == "..");
-                    if (climbingCount > 1)
-                    {
-                        var offendingSegments = imageSourcePathSegments.TakeWhile(segment => segment == "..");
-                        throw this.GetPathError(relativeMapFolder, imageSource, $"Tilesheet paths must not climb more than one directory ({string.Join('/', offendingSegments)}/).");
-                    }
+                    if (pathSegments[0] != climbSegment || pathSegments.Count(segment => segment == climbSegment) > 1)
+                        throw this.GetPathError(relativeMapFolder, imageSource, $"Directory climbing ({climbSegment}/) is only permitted once at the start of the path.");
                 }
             }
 
@@ -480,7 +481,7 @@ internal sealed class ModContentManager : BaseContentManager
         }
 
         // get relative to map file unless path has directory climbing
-        if (!PathUtilities.GetSegments(relativePath).Contains(".."))
+        if (!relativePath.StartsWith("..") && PathUtilities.GetSegments(relativePath, 2)[0] != "..") // directory climbing can only be at the start of the path
         {
             string localKey = Path.Combine(modRelativeMapFolder, relativePath);
             if (this.GetModFile<Texture2D>(localKey).Exists)

--- a/src/SMAPI/Framework/ContentManagers/ModContentManager.cs
+++ b/src/SMAPI/Framework/ContentManagers/ModContentManager.cs
@@ -415,14 +415,16 @@ internal sealed class ModContentManager : BaseContentManager
             if (Path.IsPathRooted(imageSource))
                 throw this.GetPathError(relativeMapFolder, imageSource, $"Tilesheet paths must not be an absolute path ({Path.GetPathRoot(imageSource)}).");
 
-            string[] imageSourcePathSegments = PathUtilities.GetSegments(imageSource);
-            if (imageSourcePathSegments.Contains(".."))
             {
-                int climbingCount = imageSourcePathSegments.Count(segment => segment.Equals("..", StringComparison.OrdinalIgnoreCase));
-                if (climbingCount > 1)
+                string[] imageSourcePathSegments = PathUtilities.GetSegments(imageSource);
+                if (imageSourcePathSegments.Contains(".."))
                 {
-                    var offendingSegments = imageSourcePathSegments.TakeWhile(seg => seg.Equals(".."));
-                    throw this.GetPathError(relativeMapFolder, imageSource, $"Tilesheet paths must not climb more than one directory ({string.Join('/', offendingSegments)}/).");
+                    int climbingCount = imageSourcePathSegments.Count(segment => segment == "..");
+                    if (climbingCount > 1)
+                    {
+                        var offendingSegments = imageSourcePathSegments.TakeWhile(segment => segment == "..");
+                        throw this.GetPathError(relativeMapFolder, imageSource, $"Tilesheet paths must not climb more than one directory ({string.Join('/', offendingSegments)}/).");
+                    }
                 }
             }
 

--- a/src/SMAPI/Framework/ContentManagers/ModContentManager.cs
+++ b/src/SMAPI/Framework/ContentManagers/ModContentManager.cs
@@ -412,9 +412,8 @@ internal sealed class ModContentManager : BaseContentManager
                 imageSource = imageSource[(relativeMapFolder.Length + 1)..];
 
             // validate tilesheet path
-            string errorPrefix = $"{this.ModName} loaded map '{relativeMapPath}' with invalid tilesheet path '{imageSource}'.";
             if (Path.IsPathRooted(imageSource))
-                throw new SContentLoadException(ContentLoadErrorType.InvalidData, $"{errorPrefix} Tilesheet paths must not be an absolute path ({Path.GetPathRoot(imageSource)}).");
+                throw this.GetPathError(relativeMapFolder, imageSource, $"Tilesheet paths must not be an absolute path ({Path.GetPathRoot(imageSource)}).");
 
             string[] imageSourcePathSegments = PathUtilities.GetSegments(imageSource);
             if (imageSourcePathSegments.Contains(".."))
@@ -422,8 +421,8 @@ internal sealed class ModContentManager : BaseContentManager
                 int climbingCount = imageSourcePathSegments.Count(segment => segment.Equals("..", StringComparison.OrdinalIgnoreCase));
                 if (climbingCount > 1)
                 {
-                    string[] offendingSegments = imageSourcePathSegments.TakeWhile(seg => seg.Equals("..")).ToArray();
-                    throw new SContentLoadException(ContentLoadErrorType.InvalidData, $"{errorPrefix} Tilesheet paths must not climb more than one directory ({string.Join('/', offendingSegments)}/).");
+                    var offendingSegments = imageSourcePathSegments.TakeWhile(seg => seg.Equals(".."));
+                    throw this.GetPathError(relativeMapFolder, imageSource, $"Tilesheet paths must not climb more than one directory ({string.Join('/', offendingSegments)}/).");
                 }
             }
 
@@ -431,7 +430,7 @@ internal sealed class ModContentManager : BaseContentManager
             try
             {
                 if (!this.TryGetTilesheetAssetName(relativeMapFolder, imageSource, out IAssetName? assetName, out string? error))
-                    throw new SContentLoadException(ContentLoadErrorType.InvalidData, $"{errorPrefix} {error}");
+                    throw this.GetPathError(relativeMapFolder, imageSource, error);
 
                 if (assetName is not null)
                 {
@@ -446,7 +445,7 @@ internal sealed class ModContentManager : BaseContentManager
                 if (ex is SContentLoadException)
                     throw;
 
-                throw new SContentLoadException(ContentLoadErrorType.InvalidData, $"{errorPrefix} The tilesheet couldn't be loaded.", ex);
+                throw this.GetPathError(relativeMapFolder, imageSource, "The tilesheet couldn't be loaded.", ex);
             }
         }
     }
@@ -455,10 +454,10 @@ internal sealed class ModContentManager : BaseContentManager
     /// <param name="modRelativeMapFolder">The folder path containing the map, relative to the mod folder.</param>
     /// <param name="relativePath">The tilesheet path to load.</param>
     /// <param name="assetName">The found asset name.</param>
-    /// <param name="error">A message indicating why the file couldn't be loaded.</param>
+    /// <param name="error">A message indicating why the file couldn't be loaded, if applicable.</param>
     /// <returns>Returns whether the asset name was found.</returns>
     /// <remarks>See remarks on <see cref="FixTilesheetPaths"/>.</remarks>
-    private bool TryGetTilesheetAssetName(string modRelativeMapFolder, string relativePath, out IAssetName? assetName, out string? error)
+    private bool TryGetTilesheetAssetName(string modRelativeMapFolder, string relativePath, out IAssetName? assetName, [NotNullWhen(false)] out string? error)
     {
         error = null;
 
@@ -479,7 +478,8 @@ internal sealed class ModContentManager : BaseContentManager
         }
 
         // get relative to map file unless path has directory climbing
-        if (!PathUtilities.GetSegments(relativePath).Contains("..")) {
+        if (!PathUtilities.GetSegments(relativePath).Contains(".."))
+        {
             string localKey = Path.Combine(modRelativeMapFolder, relativePath);
             if (this.GetModFile<Texture2D>(localKey).Exists)
             {
@@ -548,5 +548,15 @@ internal sealed class ModContentManager : BaseContentManager
             key = key[..^4];
 
         return key;
+    }
+
+    /// <summary>Get an exception indicating that a map asset can't be loaded because one of its tilesheets has an invalid path.</summary>
+    /// <param name="relativeMapPath">The relative path to the folder which contains the map asset, relative to the mod folder.</param>
+    /// <param name="imageSource">The tilesheet's path to the image file.</param>
+    /// <param name="error">The error message indicating why loading it failed. (Basic metadata like the image source is prepended automatically.)</param>
+    /// <param name="ex">The inner exception which caused the error, if applicable.</param>
+    private SContentLoadException GetPathError(string relativeMapPath, string imageSource, string error, Exception? ex = null)
+    {
+        return new SContentLoadException(ContentLoadErrorType.InvalidData, $"{this.ModName} loaded map '{relativeMapPath}' with invalid tilesheet path '{imageSource}'. {error}", ex);
     }
 }


### PR DESCRIPTION
This change allows the image source of a tilesheet in a mod-loaded map to climb up a single directory in order to load the tilesheet relative to the game's root Content folder. Previously, no tilesheet climbing was allowed at all and all tilesheet image sources were always assumed to be relative to the `Content/Maps` directory by convention, limiting tilesheets to only using what could be found under Maps/. With this change, modded maps may use tilesheets whose image sources are any texture asset that can be found beneath the Content root directory (such as `LooseSprites/Cursors`), including modded assets, so long as their image sources are formatted appropriately.

In order to allow this, the tilesheet image source must start with one directory climbing segment (`../`) to climb out of the assumed Maps/ folder, with the remaining path being parsed as an asset name. For example, `../LooseSprites/Cursors` will parse to the `LooseSprites/Cursors` asset, as will `/../LooseSprites/Cursors`. Any other placement of the directory climbing segment will lead to either the usual "tilesheet couldn't be found" error. No mods will be affected by this change as any instance of tilesheet climbing was previously barred.

When directory climbing in this way, SMAPI will not look for the tilesheet as an internal asset. It must be present in the content pipeline proper. This limitation was added to prevent the possibility of climbing out of a mod's folder entirely if their map was at the root of their mod directory. This limitation will affect no existing mods as it still requires the once-disallowed directory climbing for this limitation to present itself.

Attempting to use multiple directory climbing segments in a single path, no matter where they may be, will result in a new error for climbing multiple directories specifically. Additionally, the error when a tilesheet path is considered "rooted" has been separated into its own check with a new error message stating that the path must not be absolute. Both of these updated error messages will show the offending path or path segments in the log, though whether it's desirable to instead show constants like `C:/` or `../../` no matter the path is up to personal taste.

The tilesheet image sources used for testing and their results were:

- `../LooseSprites/Cursors` -> OK
- `/../LooseSprites/Cursors` -> OK
- `/LooseSprites/Cursors` -> Couldn't be found error
- `../../LooseSprites/Cursors` -> Multiple climbing error
- `../../../../LooseSprites/Cursors` -> Multiple climbing error
- `LooseSprites/Cursors` -> Couldn't be found error
- `../Maps/../LooseSprites/Cursors` -> Multiple climbing error
- `Mines/../LooseSprites/Cursors` -> SMAPI: Couldn't be found error, Content Patcher: Caught early, relative path error

![StardewModdingAPI-2025-06-22-19-18-10892](https://github.com/user-attachments/assets/1166e4c8-7a18-4c73-87d1-cc3d2a66c1bc)
