### PR TITLE
Use correct language when propagating textures

### DIFF
--- a/src/SMAPI/Metadata/CoreAssetPropagator.cs
+++ b/src/SMAPI/Metadata/CoreAssetPropagator.cs
@@ -170,7 +170,11 @@ internal class CoreAssetPropagator
             Lazy<Texture2D?> newTexture = new(() =>
             {
                 if (this.DisposableContentManager.DoesAssetExist<Texture2D>(name))
-                    return this.DisposableContentManager.LoadLocalized<Texture2D>(name, language, useCache: false);
+                {
+                    return forLocalizedAsset
+                        ? this.DisposableContentManager.LoadLocalized<Texture2D>(name, language, useCache: false)
+                        : this.DisposableContentManager.LoadLocalized<Texture2D>(name, name.LanguageCode ?? this.DisposableContentManager.Language, useCache: false);
+                }
 
                 this.Monitor.Log($"Skipped reload for '{name.Name}' because the underlying asset no longer exists.", LogLevel.Warn);
                 return null;

--- a/src/SMAPI/Metadata/CoreAssetPropagator.cs
+++ b/src/SMAPI/Metadata/CoreAssetPropagator.cs
@@ -184,7 +184,7 @@ internal class CoreAssetPropagator
                     if (newTexture.Value is null)
                         break;
 
-                    Texture2D texture = contentManager.LoadLocalized<Texture2D>(name, language, useCache: true);
+                    Texture2D texture = contentManager.LoadLocalized<Texture2D>(name, name.LanguageCode ?? contentManager.Language, useCache: true);
                     texture.CopyFromTexture(newTexture.Value);
                     changed = true;
                 }

--- a/src/SMAPI/Metadata/CoreAssetPropagator.cs
+++ b/src/SMAPI/Metadata/CoreAssetPropagator.cs
@@ -91,15 +91,9 @@ internal class CoreAssetPropagator
 
             if (textureAssets.Any())
             {
-                var defaultLanguage = this.MainContentManager.GetCurrentLanguage();
-
                 foreach (IAssetName assetName in textureAssets)
                 {
-                    var language = assetName.LanguageCode ?? defaultLanguage;
-                    if (language == LocalizedContentManager.LanguageCode.mod && LocalizedContentManager.CurrentModLanguage is null)
-                        language = defaultLanguage;
-
-                    bool changed = this.PropagateTexture(assetName, language, contentManagers, ignoreWorld);
+                    bool changed = this.PropagateTexture(assetName, contentManagers, ignoreWorld);
                     if (changed)
                         propagatedAssets[assetName] = true;
                 }
@@ -139,14 +133,19 @@ internal class CoreAssetPropagator
     *********/
     /// <summary>Propagate changes to a cached texture asset.</summary>
     /// <param name="assetName">The asset name to reload.</param>
-    /// <param name="language">The language for which to get assets.</param>
     /// <param name="contentManagers">The content managers whose assets to update.</param>
     /// <param name="ignoreWorld">Whether the in-game world is fully unloaded (e.g. on the title screen), so there's no need to propagate changes into the world.</param>
     /// <returns>Returns whether an asset was loaded.</returns>
     [SuppressMessage("ReSharper", "StringLiteralTypo", Justification = "These deliberately match the asset names.")]
-    private bool PropagateTexture(IAssetName assetName, LocalizedContentManager.LanguageCode language, IList<IContentManager> contentManagers, bool ignoreWorld)
+    private bool PropagateTexture(IAssetName assetName, IList<IContentManager> contentManagers, bool ignoreWorld)
     {
         bool changed = false;
+
+        // get default language
+        // This method replaces the textures that would be loaded if you called `contentManager.Load<Texture2D>(assetName)`,
+        // which internally maps to `contentManager.LoadLocalized<Texture2D>(assetName, currentLanguage)` regardless of
+        // the asset name's language. If the asset name includes a locale, `LoadLocalized` handles that internally.
+        LocalizedContentManager.LanguageCode currentLanguage = LocalizedContentManager.CurrentLanguageCode;
 
         // update textures in-place (0 = localized asset name, 1 = base asset name)
         for (int i = 0; i < 2; i++)
@@ -170,11 +169,7 @@ internal class CoreAssetPropagator
             Lazy<Texture2D?> newTexture = new(() =>
             {
                 if (this.DisposableContentManager.DoesAssetExist<Texture2D>(name))
-                {
-                    return forLocalizedAsset
-                        ? this.DisposableContentManager.LoadLocalized<Texture2D>(name, language, useCache: false)
-                        : this.DisposableContentManager.LoadLocalized<Texture2D>(name, name.LanguageCode ?? this.DisposableContentManager.Language, useCache: false);
-                }
+                    return this.DisposableContentManager.LoadLocalized<Texture2D>(name, currentLanguage, useCache: false);
 
                 this.Monitor.Log($"Skipped reload for '{name.Name}' because the underlying asset no longer exists.", LogLevel.Warn);
                 return null;
@@ -188,7 +183,7 @@ internal class CoreAssetPropagator
                     if (newTexture.Value is null)
                         break;
 
-                    Texture2D texture = contentManager.LoadLocalized<Texture2D>(name, name.LanguageCode ?? contentManager.Language, useCache: true);
+                    Texture2D texture = contentManager.LoadLocalized<Texture2D>(name, currentLanguage, useCache: true);
                     texture.CopyFromTexture(newTexture.Value);
                     changed = true;
                 }


### PR DESCRIPTION
This attempts to fix a situation where a mod (like [FIASA](https://www.nexusmods.com/stardewvalley/mods/33880)) had a tilesheet reference explicitly loading a localized tilesheet when the user isn't playing in that language which can chain react into causing every content manager to load that localized version when its trying to propagate to each of their caches.

Before: https://smapi.io/log/8e5b17a013ce4582bed7dddb5cb0fc8e?Levels=trace~debug~info~warn~error~alert~critical&Page=37&PerPage=1000
<img width="3439" height="313" alt="image" src="https://github.com/user-attachments/assets/f326ee23-659f-4aa6-a5a8-7240ca95d81d" />

After: https://smapi.io/log/5162e2ea154146158fd2dcb1a7b3a338?Levels=trace%7Edebug%7Einfo%7Ewarn%7Eerror%7Ealert%7Ecritical&Page=36&PerPage=1000
<img width="2565" height="181" alt="image" src="https://github.com/user-attachments/assets/fec00922-33b4-4d18-9e79-e02759ecf5ca" />
