### PR TITLE
Fix farmhouse map propagation removing spouse room

### DIFF
--- a/src/SMAPI/Metadata/CoreAssetPropagator.cs
+++ b/src/SMAPI/Metadata/CoreAssetPropagator.cs
@@ -701,6 +701,10 @@ internal class CoreAssetPropagator
         // reapply map changes
         // This must happen after updating warps (since some map modifications like the community shortcuts add warps)
         // and after resetting interior doors' state (so they apply their modifications too).
+        if (location is FarmHouse)
+        {
+            this.Reflection.GetField<bool>(location, "displayingSpouseRoom", true).SetValue(false);
+        }
         location.MakeMapModifications(force: true);
 
         // reset player position


### PR DESCRIPTION
Currently when the farmhouse map gets reloaded, it doesn't reset the flag that independently tracks the spouse room, which results in the spouse room getting deleted.

This resets that flag so when map modifications occur the spouse room gets added back in correctly, which is useful if mods changed the spouse room asset prior to farmhouse reloading.