### PR TITLE
Add input API method to press a button

### DIFF
--- a/src/SMAPI/Framework/ModHelpers/InputHelper.cs
+++ b/src/SMAPI/Framework/ModHelpers/InputHelper.cs
@@ -47,6 +47,12 @@ internal class InputHelper : BaseHelper, IInputHelper
     }
 
     /// <inheritdoc />
+    public void Press(SButton button)
+    {
+        this.CurrentInputState().OverrideButton(button, setDown: true);
+    }
+
+    /// <inheritdoc />
     public void Suppress(SButton button)
     {
         this.CurrentInputState().OverrideButton(button, setDown: false);
@@ -84,11 +90,5 @@ internal class InputHelper : BaseHelper, IInputHelper
     public SButtonState GetState(SButton button)
     {
         return this.CurrentInputState().GetState(button);
-    }
-
-    /// <inheritdoc />
-    public void OverrideButton(SButton button, bool setDown)
-    {
-        this.CurrentInputState().OverrideButton(button, setDown);
     }
 }

--- a/src/SMAPI/Framework/ModHelpers/InputHelper.cs
+++ b/src/SMAPI/Framework/ModHelpers/InputHelper.cs
@@ -85,4 +85,10 @@ internal class InputHelper : BaseHelper, IInputHelper
     {
         return this.CurrentInputState().GetState(button);
     }
+
+    /// <inheritdoc />
+    public void OverrideButton(SButton button, bool setDown)
+    {
+        this.CurrentInputState().OverrideButton(button, setDown);
+    }
 }

--- a/src/SMAPI/IInputHelper.cs
+++ b/src/SMAPI/IInputHelper.cs
@@ -30,4 +30,9 @@ public interface IInputHelper : IModLinked
     /// <summary>Get the state of a button.</summary>
     /// <param name="button">The button to check.</param>
     SButtonState GetState(SButton button);
+
+    /// <summary>Override the state of a button.</summary>
+    /// <param name="button">The button to override.</param>
+    /// <param name="setDown">A new button state.</param>
+    void OverrideButton(SButton button, bool setDown);
 }

--- a/src/SMAPI/IInputHelper.cs
+++ b/src/SMAPI/IInputHelper.cs
@@ -16,8 +16,22 @@ public interface IInputHelper : IModLinked
     /// <param name="button">The button.</param>
     bool IsSuppressed(SButton button);
 
+    /// <summary>Mark a button as pressed.</summary>
+    /// <param name="button">The button to press.</param>
+    /// <remarks>
+    ///   <para>For both mods and the base game, this is equivalent to the button being physically pressed by the player. It will be released on the next input tick by default; it can be pressed again each tick to hold it down.</para>
+    ///
+    ///   <para>See <see cref="Suppress"/> for the inverse.</para>
+    /// </remarks>
+    void Press(SButton button);
+
     /// <summary>Prevent the game from handling a button press. This doesn't prevent other mods from receiving the event.</summary>
     /// <param name="button">The button to suppress.</param>
+    /// <remarks>
+    ///   <para>If the button is being held, it'll remain suppressed until the player releases it or until <see cref="Press"/> is called for the same button.</para>
+    /// 
+    ///   <para>See <see cref="Press"/> for the inverse.</para>
+    /// </remarks>
     void Suppress(SButton button);
 
     /// <summary>Suppress the immediate change to a scroll wheel value.</summary>
@@ -30,9 +44,4 @@ public interface IInputHelper : IModLinked
     /// <summary>Get the state of a button.</summary>
     /// <param name="button">The button to check.</param>
     SButtonState GetState(SButton button);
-
-    /// <summary>Override the state of a button.</summary>
-    /// <param name="button">The button to override.</param>
-    /// <param name="setDown">A new button state.</param>
-    void OverrideButton(SButton button, bool setDown);
 }


### PR DESCRIPTION
I'm working on a mod that automates the Farmer's actions, including movement. The animation breaks when I try to move the character with SetMovingUp() and similar methods. I believe this is because the Game1.UpdateControllerInput() method Halt() the character and resets an animation if there is no input.

`if ((!moveUpHeld && !moveRightHeld && !moveDownHeld && !moveLeftHeld && !player.UsingTool) || activeClickableMenu != null)
{
   player.Halt();
}`

This PR exposes already existing OverrideButton method to the mod API.