### PR TITLE
Add shebangs to allow running PowerShell scripts directly

### DIFF
--- a/build/scripts/prepare-install-package.ps1
+++ b/build/scripts/prepare-install-package.ps1
@@ -1,3 +1,5 @@
+#!/usr/bin/env pwsh
+
 #
 #
 # Note: On Windows, this script *does not* set Linux permissions. The final changes are handled by the

--- a/build/scripts/set-smapi-version.ps1
+++ b/build/scripts/set-smapi-version.ps1
@@ -1,3 +1,5 @@
+#!/usr/bin/env pwsh
+
 . "$PSScriptRoot\lib\in-place-regex.ps1"
 
 # get version number


### PR DESCRIPTION
A minor convenience PR to save a small amount of typing when working with local SMAPI builds.