### PR TITLE
fix: add arrow key command history navigation for macOS/Linux console

### DIFF
--- a/src/SMAPI/Framework/Logging/LogManager.cs
+++ b/src/SMAPI/Framework/Logging/LogManager.cs
@@ -124,12 +124,87 @@ internal class LogManager : IDisposable
         // start handling command line input
         Thread inputThread = new(() =>
         {
+            List<string> history = [];
+            StringBuilder currentInput = new();
+            int historyIndex = -1;
+
             while (true)
             {
+                // Windows handles arrow keys natively
+#if SMAPI_FOR_WINDOWS
                 // get input
                 string? input = Console.ReadLine();
                 if (string.IsNullOrWhiteSpace(input))
                     continue;
+                // MacOS/Linux: read character by character to handle arrow keys
+#else
+                    string? input = null;
+                    currentInput.Clear();
+                    historyIndex = -1;
+
+                    while(true)
+                    {
+                        ConsoleKeyInfo key = Console.ReadKey(intercept: true);
+
+                        // handle escape sequences (arrow keys)
+                        if (key.Key == ConsoleKey.UpArrow)
+                        {
+                            if(history.Count == 0) continue;
+                            historyIndex = Math.Min(historyIndex + 1, history.Count - 1);
+                            ClearCurrentLine(currentInput.Length);
+                            currentInput.Clear();
+                            currentInput.Append(history[historyIndex]);
+                            Console.Write(currentInput);
+                            continue;
+                        }
+
+                        if (key.Key == ConsoleKey.DownArrow)
+                        {
+                            ClearCurrentLine(currentInput.Length);
+                            currentInput.Clear();
+                            if (historyIndex > 0)
+                            {
+                                historyIndex--;
+                                currentInput.Append(history[historyIndex]);
+                            }
+                            else 
+                                historyIndex = -1;
+                            Console.Write(currentInput);
+                            continue;
+                        }
+
+                        // submit on Enter
+                        if (key.Key == ConsoleKey.Enter)
+                        {
+                            Console.WriteLine();
+                            input = currentInput.ToString();
+                            break;
+                        }
+
+                        // handle backspace
+                        if (key.Key == ConsoleKey.Backspace && currentInput.Length > 0)
+                        {
+                            currentInput.Remove(currentInput.Length - 1, 1);
+                            Console.Write("\b \b");
+                            continue;
+                        }
+
+                        // normal character
+                        if (!char.IsControl(key.KeyChar))
+                        {
+                            currentInput.Append(key.KeyChar);
+                            Console.Write(key.KeyChar);
+                        }
+                    }
+
+                    if (string.IsNullOrWhiteSpace(input))
+                        continue;
+#endif
+
+                // track history
+                history.Insert(0, input);
+                if (history.Count > 50)
+                    history.RemoveAt(history.Count - 1);
 
                 // handle command
                 this.Monitor.LogUserInput(input);
@@ -647,4 +722,11 @@ internal class LogManager : IDisposable
     {
         this.LogModWarningGroup(mods, mod => mod.HasWarnings(warning), level, heading, blurb);
     }
+
+    /// <summary>Clear the current console input line.</summary>
+    /// <param name="length">The number of characters to clear.</param>
+    private static void ClearCurrentLine(int length)
+    {
+        Console.Write(new string('\b', length) + new string(' ', length) + new string('\b', length));
+    } 
 }


### PR DESCRIPTION
**What does this change:** Adds arrow key command history navigation for macOS/Linux console input. On Windows this works natively, but on macOS/Linux SMAPI uses `Console.ReadLine()` which doesn't handle arrow key escape sequences. This replaces it with a `Console.ReadKey()` loop on non-Windows platforms that tracks command history and allows up/down arrow navigation. 

**Related Issue:** #1000

**How it works:**
- On macOS/Linux, reads input character by character using `Console.ReadKey()`
- Maintains a history list of up to 50 previous commands
- Up/down arrow keys navigate through history
- Backspace, Enter, and regular characters are handled manually to replicate normal input behavior

**Note:** I'm aware this is a new feature and that discussing on Disord first is recommended. This PR was submitted as part of a class assignment and may not be suitable for merging as-is, but feedback is welcome!