### PR TITLE
Defer to the game's function for getting the saves folder path.

### DIFF
--- a/src/SMAPI/Constants.cs
+++ b/src/SMAPI/Constants.cs
@@ -92,7 +92,7 @@ public static class Constants
     public static string LogDir { get; } = Path.Combine(Constants.DataPath, "ErrorLogs");
 
     /// <summary>The directory path where all saves are stored.</summary>
-    public static string SavesPath { get; } = Path.Combine(Constants.DataPath, "Saves");
+    public static string SavesPath { get => StardewValley.Program.GetSavesFolder(); }
 
     /// <summary>The name of the current save folder (if save info is available, regardless of whether the save file exists yet).</summary>
     public static string? SaveFolderName => Constants.GetSaveFolderName();


### PR DESCRIPTION
This allows the new --saves-path command line argument to work with SMAPI.

---

I'm unsure what the appropriate changes for Save Backup is. It only takes one backup a day, but if one was already taken and you use a different folder, it will not back up the new folder.

Maybe a new --saves-backup-path argument would be enough?