### PR TITLE
Add Ghostty terminal support for macOS launcher

### DIFF
--- a/src/SMAPI.Installer/assets/unix-launcher.sh
+++ b/src/SMAPI.Installer/assets/unix-launcher.sh
@@ -64,8 +64,11 @@ if [ "$(uname)" == "Darwin" ]; then
             chmod +x /tmp/open-smapi-terminal.command
             cat /tmp/open-smapi-terminal.command
 
-            # open in ITerm2 if installed, else the default Terminal
-            if [ -d "/Applications/iTerm.app" ]; then
+            # open in Ghostty or iTerm2 if installed, else the default Terminal
+            if [ -d "/Applications/Ghostty.app" ]; then
+                echo "Reopening in Ghostty..."
+                open -a "/Applications/Ghostty.app" /tmp/open-smapi-terminal.command
+            elif [ -d "/Applications/iTerm.app" ]; then
                 echo "Reopening in iTerm2..."
                 open -a "/Applications/iTerm.app" /tmp/open-smapi-terminal.command
             else


### PR DESCRIPTION
### Description
This pull request adds support for launching SMAPI in the Ghostty terminal emulator on macOS.

#### Problem
Currently, the macOS launcher script (`unix-launcher.sh`) only checks for the presence of iTerm2 before falling back to the default macOS Terminal application. Users who prefer using Ghostty have to manually edit the launcher script or run SMAPI from their terminal.

#### Solution
Added a check for `/Applications/Ghostty.app` at the top of the terminal selection logic. If Ghostty is installed, the script will reopen the SMAPI terminal command in Ghostty. The implementation matches the existing style used for iTerm2 to ensure consistency and minimize changes to core logic.