### PR TITLE
translate Generic Mod Config Menu UI strings for zh

### DIFF
--- a/src/SMAPI/i18n/zh.json
+++ b/src/SMAPI/i18n/zh.json
@@ -13,43 +13,43 @@
     *********/
     // TODO
     // 'SMAPI features' section
-    "config.section.features": "SMAPI features",
+    "config.section.features": "SMAPI 功能",
 
-    "config.check-for-updates.name": "Check for updates",
-    "config.check-for-updates.desc": "Whether to automatically check for newer versions of SMAPI and mods when you load the game. If new versions are available, an alert will be shown in the console. This doesn't affect the load time even if your connection is offline or slow, because it happens in the background.",
+    "config.check-for-updates.name": "检查更新",
+    "config.check-for-updates.desc": "加载游戏时是否自动检查 SMAPI 和模组的新版本。若有新版本可用，控制台将显示提醒。即使网络离线或缓慢，也不会影响加载时间，因为此操作在后台进行。",
 
-    "config.check-content-integrity.name": "Check content integrity",
-    "config.check-content-integrity.desc": "Whether SMAPI should check whether the game's content files are present and unmodified. This should nearly always be enabled. If disabled, SMAPI will log a warning for visibility when someone helps you troubleshoot game issues.",
+    "config.check-content-integrity.name": "检查内容完整性",
+    "config.check-content-integrity.desc": "SMAPI 是否检查游戏内容文件是否存在且未被修改。几乎始终应启用此项。若禁用，当他人帮您排查游戏问题时，SMAPI 会记录一条警告以便他人察觉。",
 
-    "config.read-console-input.name": "Read console input",
-    "config.read-console-input.desc": "Whether SMAPI should listen for console input. Disabling this will prevent you from using console commands. On some specific Linux systems, disabling this may reduce CPU usage.",
+    "config.read-console-input.name": "读取控制台输入",
+    "config.read-console-input.desc": "SMAPI 是否监听控制台输入。禁用此项将无法使用控制台命令。在某些特定 Linux 系统上，禁用此项可能降低 CPU 使用率。",
 
     // 'Console window' section
-    "config.section.console-window": "Console window",
+    "config.section.console-window": "控制台窗口",
 
-    "config.developer-mode.name": "Developer mode",
-    "config.developer-mode.desc": "Whether to show much more info in the SMAPI consoler window, intended for mod developers. Not recommended for most players.",
+    "config.developer-mode.name": "开发者模式",
+    "config.developer-mode.desc": "是否在 SMAPI 控制台窗口中显示面向模组开发者的更多详细信息。不建议大多数玩家使用。",
 
-    "config.color-scheme.name": "Color scheme",
-    "config.color-scheme.desc": "The color scheme to apply to text in the SMAPI console window. This has no effect on the game, mods, or SMAPI log file.",
-    "config.color-scheme.options.AutoDetect": "Auto-detect",
-    "config.color-scheme.options.AutoDetect.on-windows": "Auto-detect (recommended)",
-    "config.color-scheme.options.DarkBackground": "Lighter text (for dark backgrounds)",
-    "config.color-scheme.options.LightBackground": "Darker text (for light backgrounds)",
-    "config.color-scheme.options.None": "No colors",
+    "config.color-scheme.name": "配色方案",
+    "config.color-scheme.desc": "应用于 SMAPI 控制台窗口文本的配色方案。不影响游戏、模组或 SMAPI 日志文件。",
+    "config.color-scheme.options.AutoDetect": "自动检测",
+    "config.color-scheme.options.AutoDetect.on-windows": "自动检测（推荐）",
+    "config.color-scheme.options.DarkBackground": "浅色文本（适用于深色背景）",
+    "config.color-scheme.options.LightBackground": "深色文本（适用于浅色背景）",
+    "config.color-scheme.options.None": "不使用颜色",
 
     // 'Verbose logging' section
-    "config.section.verbose-logs": "Verbose logs",
-    "config.section.verbose-logs.explanation": "To help troubleshoot, SMAPI and many mods can send extra info to the SMAPI log (called 'verbose logging'). This may cause performance issues, and should usually be disabled.",
+    "config.section.verbose-logs": "详细日志",
+    "config.section.verbose-logs.explanation": "为帮助排查问题，SMAPI 和许多模组可向 SMAPI 日志发送额外信息（称为“详细日志”）。这可能导致性能问题，通常应保持禁用。",
 
-    "config.enable-for.name": "Enable for",
-    "config.enable-for.desc": "Choose which mods have verbose logging enabled.",
-    "config.enable-for.options.all": "All (not recommended)",
-    "config.enable-for.options.selected": "Mods selected below",
+    "config.enable-for.name": "启用范围",
+    "config.enable-for.desc": "选择哪些模组启用详细日志。",
+    "config.enable-for.options.all": "全部（不推荐）",
+    "config.enable-for.options.selected": "下方选中的模组",
 
     "config.enable-for-smapi.name": "SMAPI",
-    "config.enable-for-smapi.desc": "Whether to enable verbose logs for SMAPI itself.",
+    "config.enable-for-smapi.desc": "是否为 SMAPI 自身启用详细日志。",
 
     "config.enable-for-mod.name": "{{modName}}",
-    "config.enable-for-mod.desc": "Whether to enable verbose logs for the '{{modName}}' mod."
+    "config.enable-for-mod.desc": "是否为“{{modName}}”模组启用详细日志。"
 }


### PR DESCRIPTION
Translate the GMCM config UI strings into Chinese. Care was taken to ensure terminological consistency and natural phrasing that respects Chinese typesetting conventions, not just literal translation.