### PR TITLE
Add a JSON schema for Content Patcher include files

### DIFF
--- a/src/SMAPI.Web/wwwroot/schemas/content-patcher-include.json
+++ b/src/SMAPI.Web/wwwroot/schemas/content-patcher-include.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://smapi.io/schemas/content-patcher-include.json",
+    "title": "Content Patcher include file",
+    "description": "A secondary Content Patcher file loaded by an Include patch.",
+    "@documentationUrl": "https://github.com/Pathoschild/StardewMods/blob/develop/ContentPatcher/docs/author-guide/action-include.md",
+
+    "allowComments": true,
+    "allowTrailingCommas": true,
+
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "title": "Schema",
+            "description": "A reference to this JSON schema. Not part of the actual format, but useful for validation tools.",
+            "type": "string"
+        },
+        "Changes": {
+            "$ref": "content-patcher.json#/properties/Changes"
+        }
+    },
+
+    "required": ["Changes"],
+
+    "additionalProperties": false,
+    "@errorMessages": {
+        "additionalProperties": "Invalid field. An included file can only contain a Changes field."
+    }
+}


### PR DESCRIPTION
There's currently no schema for `Include` files, even though the format is a subset of the main content file — `Changes` alone, without `Format`. `content-patcher.json` can't stand in for the same reason: it requires `Format`.

This adds `content-patcher-include.json`. It `$ref`s `content-patcher.json#/properties/Changes` rather than duplicating it, so it shouldn't need maintaining alongside the main schema — I'd been using a hand-written copy of that subschema locally, and it had fallen out of date within a few months.

Thanks for publishing these — they've saved me a lot of time working on content packs. Glad to rename it, adjust the wording, or close this if you'd rather not carry another file.
